### PR TITLE
ci(dependabot): cap semver-major cooldown at 90 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     cooldown:
       semver-patch-days: 28
       semver-minor-days: 90
-      semver-major-days: 180
+      semver-major-days: 90
     commit-message:
       prefix: "chore"
     ignore:


### PR DESCRIPTION
## Summary

- Set `semver-major-days` to **90** so the Bun ecosystem cooldown block stays within GitHub’s documented range (1–90 days) for `cooldown` day values.


Made with [Cursor](https://cursor.com)