### PR TITLE
chore(deps): bump lucide-react to 1.8.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "clsx": "2.1.1",
         "drizzle-orm": "0.45.2",
         "isbot": "5.1.37",
-        "lucide-react": "0.562.0",
+        "lucide-react": "1.8.0",
         "motion": "12.23.22",
         "radix-ui": "1.4.3",
         "react": "19.2.4",
@@ -1191,7 +1191,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "clsx": "2.1.1",
     "drizzle-orm": "0.45.2",
     "isbot": "5.1.37",
-    "lucide-react": "0.562.0",
+    "lucide-react": "1.8.0",
     "radix-ui": "1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
## Summary
- Upgrade `lucide-react` from 0.562.0 to 1.8.0
- Refresh `bun.lock` for the resolved package


Made with [Cursor](https://cursor.com)