### PR TITLE
ci(dependabot): remove cooldown configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,8 +40,8 @@ updates:
 
       react-router:
         patterns:
-          - "react-router"
           - "@react-router/*"
+          - "react-router"
 
       storybook:
         patterns:
@@ -50,5 +50,5 @@ updates:
 
       react-email:
         patterns:
-          - "react-email"
           - "@react-email/*"
+          - "react-email"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 2
-    cooldown:
-      semver-patch-days: 28
-      semver-minor-days: 90
-      semver-major-days: 90
     commit-message:
       prefix: "chore(deps)"
     ignore:


### PR DESCRIPTION
## Summary
- Remove the `cooldown` block from the Bun ecosystem entry in Dependabot config (semver patch/minor/major day delays).


Made with [Cursor](https://cursor.com)