### PR TITLE
docs(agents): add delegation guidance to create-pr skill

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -3,10 +3,15 @@ name: create-pr
 description: >-
   Create GitHub pull requests following conventional naming patterns, creating a
   branch if needed. Use when the user asks to create or open a PR, submit
-  changes for review, or push work to GitHub.
+  changes for review, or push work to GitHub. Delegate via Task (shell
+  subagent), not inline in the main session.
 ---
 
 # Create PR
+
+## Delegation
+
+Use **Task** with **subagent_type** **shell**; use **generalPurpose** only if the repo must be inspected before commands. Do not run `git`/`gh` in the main session.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- extend the create-pr skill description to mention delegating via Task (shell subagent)
- add a Delegation section instructing use of Task/shell and avoiding git/gh in the main session

Made with [Cursor](https://cursor.com)