### PR TITLE
chore: disable bun dependabot and set quarterly intervals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     open-pull-requests-limit: 1
 
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 2
+      interval: "quarterly"
+    open-pull-requests-limit: 0  # Disabled. To enable, change to > 0, recommended value: 10
     commit-message:
       prefix: "chore(deps)"
     ignore:


### PR DESCRIPTION
## Summary
- Disabled Dependabot for bun ecosystem by setting open-pull-requests-limit to 0
- Changed schedule interval to quarterly for both github-actions and bun ecosystems
- Added inline comment explaining how to re-enable bun Dependabot


Made with [Cursor](https://cursor.com)