### PR TITLE
feat(content): add badge and medium background to Section

### DIFF
--- a/apps/content/components/section/section.stories.tsx
+++ b/apps/content/components/section/section.stories.tsx
@@ -1,16 +1,18 @@
 import { faker } from "@faker-js/faker"
-import type { Meta, StoryObj } from "@storybook/react"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { Badge } from "@/ui/badge"
 import { Section } from "./section"
 
 const meta = {
   title: "Apps/Content/Section",
   component: Section,
   parameters: {
-    layout: "centered",
+    layout: "fullscreen",
   },
   tags: ["autodocs"],
   argTypes: {
     children: { control: false },
+    badge: { control: false },
   },
 } satisfies Meta<typeof Section>
 
@@ -20,6 +22,33 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     title: faker.lorem.sentence(),
+    description: faker.lorem.paragraph(),
+  },
+}
+
+export const WithBadge: Story = {
+  args: {
+    title: faker.lorem.sentence(),
+    description: faker.lorem.paragraph(),
+    badge: (
+      <Badge variant="outline" className="px-3 py-2 text-muted-foreground">
+        <span className="mr-1 size-3 rounded-full bg-amber-600" />
+        Featured
+      </Badge>
+    ),
+  },
+}
+
+export const MediumBackground: Story = {
+  args: {
+    title: faker.lorem.sentence(),
+    description: faker.lorem.paragraph(),
+    background: "medium",
+  },
+}
+
+export const DescriptionOnly: Story = {
+  args: {
     description: faker.lorem.paragraph(),
   },
 }

--- a/apps/content/components/section/section.test.tsx
+++ b/apps/content/components/section/section.test.tsx
@@ -24,14 +24,35 @@ describe("<Section />", () => {
     expect(screen.getByText("Test description")).toBeInTheDocument()
   })
 
+  it("renders description without title", () => {
+    render(<Section description="Test description">Content</Section>)
+    expect(screen.getByText("Test description")).toBeInTheDocument()
+    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument()
+  })
+
+  it("renders badge when provided", () => {
+    render(
+      <Section badge={<span>Badge label</span>} title="Test Title">
+        Content
+      </Section>,
+    )
+    expect(screen.getByText("Badge label")).toBeInTheDocument()
+    expect(screen.getByText("Test Title")).toBeInTheDocument()
+  })
+
   it("renders all props together", () => {
     render(
-      <Section title="Test Title" description="Test description">
+      <Section
+        title="Test Title"
+        description="Test description"
+        badge={<span>Badge label</span>}
+      >
         Test content
       </Section>,
     )
     expect(screen.getByText("Test Title")).toBeInTheDocument()
     expect(screen.getByText("Test description")).toBeInTheDocument()
+    expect(screen.getByText("Badge label")).toBeInTheDocument()
     expect(screen.getByText("Test content")).toBeInTheDocument()
   })
 
@@ -44,5 +65,13 @@ describe("<Section />", () => {
     const { container } = render(<Section id="custom-section">Content</Section>)
     const section = container.querySelector("section")
     expect(section).toHaveAttribute("id", "custom-section")
+  })
+
+  it("applies medium background variant", () => {
+    const { container } = render(
+      <Section background="medium">Content</Section>,
+    )
+    const section = container.querySelector("section")
+    expect(section).toHaveClass("bg-muted/50")
   })
 })

--- a/apps/content/components/section/section.test.tsx
+++ b/apps/content/components/section/section.test.tsx
@@ -68,9 +68,7 @@ describe("<Section />", () => {
   })
 
   it("applies medium background variant", () => {
-    const { container } = render(
-      <Section background="medium">Content</Section>,
-    )
+    const { container } = render(<Section background="medium">Content</Section>)
     const section = container.querySelector("section")
     expect(section).toHaveClass("bg-muted/50")
   })

--- a/apps/content/components/section/section.tsx
+++ b/apps/content/components/section/section.tsx
@@ -14,6 +14,7 @@ const sectionVariants = cva("", {
     background: {
       none: "",
       light: "bg-muted/30",
+      medium: "bg-muted/50",
       dark: "bg-muted",
     },
   },
@@ -26,16 +27,16 @@ const sectionVariants = cva("", {
 type SectionProps = {
   children?: ReactNode
   id?: string
-} & VariantProps<typeof sectionVariants> &
-  (
-    | { title: string; description?: string }
-    | { title?: never; description?: never }
-  )
+  title?: string
+  description?: string
+  badge?: ReactNode
+} & VariantProps<typeof sectionVariants>
 
 export const Section = ({
   children,
   title,
   description,
+  badge,
   id,
   spacingSize,
   background,
@@ -46,7 +47,10 @@ export const Section = ({
       className={cn(sectionVariants({ spacingSize, background }))}
     >
       <div className="container mx-auto px-5">
-        {title && (
+        {badge && (
+          <div className="mx-auto mb-4 flex justify-center">{badge}</div>
+        )}
+        {(title || description) && (
           <div className="mx-auto mb-20 max-w-2xl text-center">
             {title && (
               <Heading level={2} className="mb-4 text-4xl">


### PR DESCRIPTION
## Summary
- Add optional `badge` prop and `medium` background variant to the Section component
- Relax header props so title and description are independently optional
- Update Section tests and Storybook stories for the new API


Made with [Cursor](https://cursor.com)