### PR TITLE
test(e2e): use single worker to avoid overloading dev server

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Single worker avoids overloading the local dev server during e2e runs. */
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? "dot" : "list",
   /* Limit the number of failures on CI to save resources */


### PR DESCRIPTION
## Summary
- Set Playwright `workers` to `1` for all environments (local and CI)
- Prevents parallel e2e tests from overloading the local dev server during runs

## Test plan
- [ ] Run `bun run test:e2e` locally and confirm tests pass with a single worker
- [ ] Verify CI e2e job still passes


Made with [Cursor](https://cursor.com)