### PR TITLE
feat(brand): add ProseArticle layout for read-based pages

### DIFF
--- a/apps/blog/routes/post.tsx
+++ b/apps/blog/routes/post.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft } from "lucide-react"
 import { BlogPostSummary } from "@/blog/components/blog-post-summary"
 import { postModules } from "@/blog/post-modules"
 import { getBlogPostFrontmatter, getBlogPostModuleBySlug } from "@/blog/utils"
+import { ProseArticle } from "@/brand/components/prose-article"
 import config from "@/config"
 import { MDXProvider } from "@/mdx"
 import { Link } from "@/ui/link"
@@ -44,7 +45,7 @@ function BlogPost() {
   if (!PostComponent) throw notFound()
 
   return (
-    <div className="mx-auto max-w-prose px-5 py-32 text-muted-foreground">
+    <ProseArticle>
       <nav className="mb-12">
         <Link
           size="sm"
@@ -68,6 +69,6 @@ function BlogPost() {
       <MDXProvider>
         <PostComponent />
       </MDXProvider>
-    </div>
+    </ProseArticle>
   )
 }

--- a/apps/brand/components/prose-article/index.ts
+++ b/apps/brand/components/prose-article/index.ts
@@ -1,0 +1,1 @@
+export * from "./prose-article"

--- a/apps/brand/components/prose-article/prose-article.stories.tsx
+++ b/apps/brand/components/prose-article/prose-article.stories.tsx
@@ -1,0 +1,42 @@
+import { faker } from "@faker-js/faker"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { Heading, P } from "@/ui/typography"
+import { ProseArticle } from "./prose-article"
+
+const meta = {
+  title: "Apps/Brand/ProseArticle",
+  component: ProseArticle,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    children: { control: false },
+  },
+} satisfies Meta<typeof ProseArticle>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: faker.lorem.sentence(),
+    children: (
+      <>
+        <Heading level={3}>Section heading</Heading>
+        <P>{faker.lorem.paragraphs(2)}</P>
+      </>
+    ),
+  },
+}
+
+export const WithoutTitle: Story = {
+  args: {
+    children: (
+      <>
+        <Heading level={3}>Section heading</Heading>
+        <P>{faker.lorem.paragraphs(2)}</P>
+      </>
+    ),
+  },
+}

--- a/apps/brand/components/prose-article/prose-article.test.tsx
+++ b/apps/brand/components/prose-article/prose-article.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ProseArticle } from "./prose-article"
+
+describe("<ProseArticle />", () => {
+  it("renders children content", () => {
+    render(<ProseArticle>Test content</ProseArticle>)
+    expect(screen.getByText("Test content")).toBeInTheDocument()
+  })
+
+  it("renders title when provided", () => {
+    render(<ProseArticle title="Test Title">Content</ProseArticle>)
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Test Title" }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Content")).toBeInTheDocument()
+  })
+
+  it("renders as an article element", () => {
+    const { container } = render(<ProseArticle>Content</ProseArticle>)
+    expect(container.querySelector("article")).toBeInTheDocument()
+  })
+})

--- a/apps/brand/components/prose-article/prose-article.tsx
+++ b/apps/brand/components/prose-article/prose-article.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react"
+import { Heading } from "@/ui/typography"
+
+type ProseArticleProps = {
+  children?: ReactNode
+  title?: string
+}
+
+function ProseArticle({ children, title }: ProseArticleProps) {
+  return (
+    <article className="mx-auto max-w-prose px-5 py-32 text-muted-foreground">
+      {title && (
+        <Heading level={1} className="mb-20 text-center text-foreground">
+          {title}
+        </Heading>
+      )}
+      {children}
+    </article>
+  )
+}
+
+export { ProseArticle, type ProseArticleProps }

--- a/apps/brand/routes/privacy.tsx
+++ b/apps/brand/routes/privacy.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import config from "@/config"
 import { Heading, List, Muted, P } from "@/ui/typography"
-import { Section } from "../components/section"
+import { ProseArticle } from "../components/prose-article"
 
 export const Route = createFileRoute("/_brand-layout/privacy")({
   component: Privacy,
@@ -13,228 +13,225 @@ function Privacy() {
   const websiteUrl = config.core.websiteUrl
 
   return (
-    <Section title="Privacy Policy">
-      <div className="mx-auto max-w-prose text-muted-foreground">
-        <Muted>Last updated: [Date]</Muted>
+    <ProseArticle title="Privacy Policy">
+      <Muted>Last updated: [Date]</Muted>
 
-        <Heading level={3}>1. Introduction</Heading>
-        <P>
-          This Privacy Policy explains how {projectName} ("we", "us", or "our")
-          collects, uses, and protects your personal information when you use
-          our website at{" "}
-          <a
-            href={websiteUrl}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {websiteUrl}
-          </a>{" "}
-          and our services.
-        </P>
+      <Heading level={3}>1. Introduction</Heading>
+      <P>
+        This Privacy Policy explains how {projectName} ("we", "us", or "our")
+        collects, uses, and protects your personal information when you use our
+        website at{" "}
+        <a
+          href={websiteUrl}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {websiteUrl}
+        </a>{" "}
+        and our services.
+      </P>
 
-        <Heading level={3}>2. Information We Collect</Heading>
-        <P>We collect information in the following ways:</P>
+      <Heading level={3}>2. Information We Collect</Heading>
+      <P>We collect information in the following ways:</P>
 
-        <P>
-          <strong>Information you provide directly:</strong>
-        </P>
-        <List>
-          <li>
-            <strong>Account information</strong> — Email address when you create
-            an account or sign in
-          </li>
-          <li>
-            <strong>Payment information</strong> — Billing details when you make
-            a purchase (processed securely by our payment provider)
-          </li>
-          <li>
-            <strong>Communications</strong> — Information you provide when
-            contacting us for support
-          </li>
-        </List>
+      <P>
+        <strong>Information you provide directly:</strong>
+      </P>
+      <List>
+        <li>
+          <strong>Account information</strong> — Email address when you create
+          an account or sign in
+        </li>
+        <li>
+          <strong>Payment information</strong> — Billing details when you make a
+          purchase (processed securely by our payment provider)
+        </li>
+        <li>
+          <strong>Communications</strong> — Information you provide when
+          contacting us for support
+        </li>
+      </List>
 
-        <P>
-          <strong>Information collected automatically:</strong>
-        </P>
-        <List>
-          <li>
-            <strong>Usage data</strong> — Pages visited, features used, and
-            interactions with the website
-          </li>
-          <li>
-            <strong>Device information</strong> — Browser type, operating
-            system, and device identifiers
-          </li>
-          <li>
-            <strong>Log data</strong> — IP address, access times, and referring
-            URLs
-          </li>
-        </List>
+      <P>
+        <strong>Information collected automatically:</strong>
+      </P>
+      <List>
+        <li>
+          <strong>Usage data</strong> — Pages visited, features used, and
+          interactions with the website
+        </li>
+        <li>
+          <strong>Device information</strong> — Browser type, operating system,
+          and device identifiers
+        </li>
+        <li>
+          <strong>Log data</strong> — IP address, access times, and referring
+          URLs
+        </li>
+      </List>
 
-        <Heading level={3}>3. How We Use Your Information</Heading>
-        <P>We use the information we collect to:</P>
-        <List>
-          <li>Provide and maintain our services</li>
-          <li>Process your purchases and manage your account</li>
-          <li>
-            Send transactional emails (authentication codes, purchase
-            confirmations, account notifications)
-          </li>
-          <li>Respond to your support requests</li>
-          <li>Improve our website and services</li>
-          <li>Detect and prevent fraud or abuse</li>
-          <li>Comply with legal obligations</li>
-        </List>
+      <Heading level={3}>3. How We Use Your Information</Heading>
+      <P>We use the information we collect to:</P>
+      <List>
+        <li>Provide and maintain our services</li>
+        <li>Process your purchases and manage your account</li>
+        <li>
+          Send transactional emails (authentication codes, purchase
+          confirmations, account notifications)
+        </li>
+        <li>Respond to your support requests</li>
+        <li>Improve our website and services</li>
+        <li>Detect and prevent fraud or abuse</li>
+        <li>Comply with legal obligations</li>
+      </List>
 
-        <Heading level={3}>4. Third-Party Services</Heading>
-        <P>
-          We use third-party services to operate {projectName}. These services
-          may collect and process your data according to their own privacy
-          policies:
-        </P>
-        <List>
-          {/* Update this list with your actual third-party service providers */}
-          <li>
-            <strong>[Hosting Provider]</strong> — Website hosting and
-            infrastructure
-          </li>
-          <li>
-            <strong>[Payment Provider]</strong> — Payment processing and billing
-          </li>
-          <li>
-            <strong>[Email Provider]</strong> — Transactional email delivery
-          </li>
-          <li>
-            <strong>[Analytics Provider]</strong> — Website analytics (if
-            applicable)
-          </li>
-        </List>
+      <Heading level={3}>4. Third-Party Services</Heading>
+      <P>
+        We use third-party services to operate {projectName}. These services may
+        collect and process your data according to their own privacy policies:
+      </P>
+      <List>
+        {/* Update this list with your actual third-party service providers */}
+        <li>
+          <strong>[Hosting Provider]</strong> — Website hosting and
+          infrastructure
+        </li>
+        <li>
+          <strong>[Payment Provider]</strong> — Payment processing and billing
+        </li>
+        <li>
+          <strong>[Email Provider]</strong> — Transactional email delivery
+        </li>
+        <li>
+          <strong>[Analytics Provider]</strong> — Website analytics (if
+          applicable)
+        </li>
+      </List>
 
-        <Heading level={3}>5. Cookies and Tracking</Heading>
-        <P>We use cookies and similar technologies for:</P>
-        <List>
-          <li>
-            <strong>Essential cookies</strong> — Required for authentication and
-            session management
-          </li>
-          <li>
-            <strong>Analytics</strong> — To understand how visitors use our
-            website
-          </li>
-        </List>
-        <P>
-          {/* Update this based on your analytics provider */}
-          You can manage cookie preferences through your browser settings.
-        </P>
+      <Heading level={3}>5. Cookies and Tracking</Heading>
+      <P>We use cookies and similar technologies for:</P>
+      <List>
+        <li>
+          <strong>Essential cookies</strong> — Required for authentication and
+          session management
+        </li>
+        <li>
+          <strong>Analytics</strong> — To understand how visitors use our
+          website
+        </li>
+      </List>
+      <P>
+        {/* Update this based on your analytics provider */}
+        You can manage cookie preferences through your browser settings.
+      </P>
 
-        <Heading level={3}>6. Data Retention</Heading>
-        <P>We retain your personal information for as long as necessary to:</P>
-        <List>
-          <li>Provide our services to you</li>
-          <li>Comply with legal obligations</li>
-          <li>Resolve disputes and enforce our agreements</li>
-        </List>
-        <P>
-          When you delete your account, we will delete or anonymize your
-          personal information within 30 days, except where we are required to
-          retain it for legal purposes.
-        </P>
+      <Heading level={3}>6. Data Retention</Heading>
+      <P>We retain your personal information for as long as necessary to:</P>
+      <List>
+        <li>Provide our services to you</li>
+        <li>Comply with legal obligations</li>
+        <li>Resolve disputes and enforce our agreements</li>
+      </List>
+      <P>
+        When you delete your account, we will delete or anonymize your personal
+        information within 30 days, except where we are required to retain it
+        for legal purposes.
+      </P>
 
-        <Heading level={3}>7. Data Security</Heading>
-        <P>
-          We implement appropriate technical and organizational measures to
-          protect your personal information, including:
-        </P>
-        <List>
-          <li>Encryption of data in transit (HTTPS/TLS)</li>
-          <li>Secure session management</li>
-          <li>Regular security reviews</li>
-        </List>
-        <P>
-          However, no method of transmission over the internet is 100% secure.
-          We cannot guarantee absolute security of your data.
-        </P>
+      <Heading level={3}>7. Data Security</Heading>
+      <P>
+        We implement appropriate technical and organizational measures to
+        protect your personal information, including:
+      </P>
+      <List>
+        <li>Encryption of data in transit (HTTPS/TLS)</li>
+        <li>Secure session management</li>
+        <li>Regular security reviews</li>
+      </List>
+      <P>
+        However, no method of transmission over the internet is 100% secure. We
+        cannot guarantee absolute security of your data.
+      </P>
 
-        <Heading level={3}>8. Your Rights</Heading>
-        <P>
-          Depending on your location, you may have the following rights
-          regarding your personal information:
-        </P>
-        <List>
-          <li>
-            <strong>Access</strong> — Request a copy of the personal information
-            we hold about you
-          </li>
-          <li>
-            <strong>Correction</strong> — Request correction of inaccurate or
-            incomplete information
-          </li>
-          <li>
-            <strong>Deletion</strong> — Request deletion of your personal
-            information
-          </li>
-          <li>
-            <strong>Portability</strong> — Request a copy of your data in a
-            portable format
-          </li>
-          <li>
-            <strong>Objection</strong> — Object to processing of your personal
-            information
-          </li>
-        </List>
-        <P>
-          To exercise these rights, contact us at{" "}
-          <a
-            href={`mailto:${supportEmail}`}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {supportEmail}
-          </a>
-          .
-        </P>
+      <Heading level={3}>8. Your Rights</Heading>
+      <P>
+        Depending on your location, you may have the following rights regarding
+        your personal information:
+      </P>
+      <List>
+        <li>
+          <strong>Access</strong> — Request a copy of the personal information
+          we hold about you
+        </li>
+        <li>
+          <strong>Correction</strong> — Request correction of inaccurate or
+          incomplete information
+        </li>
+        <li>
+          <strong>Deletion</strong> — Request deletion of your personal
+          information
+        </li>
+        <li>
+          <strong>Portability</strong> — Request a copy of your data in a
+          portable format
+        </li>
+        <li>
+          <strong>Objection</strong> — Object to processing of your personal
+          information
+        </li>
+      </List>
+      <P>
+        To exercise these rights, contact us at{" "}
+        <a
+          href={`mailto:${supportEmail}`}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {supportEmail}
+        </a>
+        .
+      </P>
 
-        <Heading level={3}>9. International Data Transfers</Heading>
-        <P>
-          Your information may be transferred to and processed in countries
-          other than your own. We ensure appropriate safeguards are in place for
-          such transfers in accordance with applicable data protection laws.
-        </P>
+      <Heading level={3}>9. International Data Transfers</Heading>
+      <P>
+        Your information may be transferred to and processed in countries other
+        than your own. We ensure appropriate safeguards are in place for such
+        transfers in accordance with applicable data protection laws.
+      </P>
 
-        <Heading level={3}>10. Children's Privacy</Heading>
-        <P>
-          {projectName} is not intended for children under 16 years of age. We
-          do not knowingly collect personal information from children. If you
-          believe we have collected information from a child, please contact us
-          immediately.
-        </P>
+      <Heading level={3}>10. Children's Privacy</Heading>
+      <P>
+        {projectName} is not intended for children under 16 years of age. We do
+        not knowingly collect personal information from children. If you believe
+        we have collected information from a child, please contact us
+        immediately.
+      </P>
 
-        <Heading level={3}>11. Changes to This Policy</Heading>
-        <P>
-          We may update this Privacy Policy from time to time. We will notify
-          you of any material changes by posting the updated policy on{" "}
-          <a
-            href={websiteUrl}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {websiteUrl}
-          </a>{" "}
-          and updating the "Last updated" date. Your continued use of{" "}
-          {projectName} after such changes constitutes acceptance of the updated
-          policy.
-        </P>
+      <Heading level={3}>11. Changes to This Policy</Heading>
+      <P>
+        We may update this Privacy Policy from time to time. We will notify you
+        of any material changes by posting the updated policy on{" "}
+        <a
+          href={websiteUrl}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {websiteUrl}
+        </a>{" "}
+        and updating the "Last updated" date. Your continued use of{" "}
+        {projectName} after such changes constitutes acceptance of the updated
+        policy.
+      </P>
 
-        <Heading level={3}>12. Contact Us</Heading>
-        <P>
-          If you have any questions about this Privacy Policy or our data
-          practices, please contact us at{" "}
-          <a
-            href={`mailto:${supportEmail}`}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {supportEmail}
-          </a>
-          .
-        </P>
-      </div>
-    </Section>
+      <Heading level={3}>12. Contact Us</Heading>
+      <P>
+        If you have any questions about this Privacy Policy or our data
+        practices, please contact us at{" "}
+        <a
+          href={`mailto:${supportEmail}`}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {supportEmail}
+        </a>
+        .
+      </P>
+    </ProseArticle>
   )
 }

--- a/apps/brand/routes/terms-and-conditions.tsx
+++ b/apps/brand/routes/terms-and-conditions.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import config from "@/config"
 import { Heading, List, Muted, P } from "@/ui/typography"
-import { Section } from "../components/section"
+import { ProseArticle } from "../components/prose-article"
 
 export const Route = createFileRoute("/_brand-layout/terms-and-conditions")({
   component: TermsAndConditions,
@@ -13,198 +13,193 @@ function TermsAndConditions() {
   const websiteUrl = config.core.websiteUrl
 
   return (
-    <Section title="Terms and Conditions">
-      <div className="mx-auto max-w-prose text-muted-foreground">
-        <Muted>Last updated: [Date]</Muted>
+    <ProseArticle title="Terms and Conditions">
+      <Muted>Last updated: [Date]</Muted>
 
-        <Heading level={3}>1. Agreement to Terms</Heading>
-        <P>
-          By accessing or using {projectName}, you agree to be bound by these
-          Terms and Conditions and our{" "}
-          <a
-            href="/privacy"
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            Privacy Policy
-          </a>
-          . If you do not agree to these terms, please do not use our services.
-        </P>
+      <Heading level={3}>1. Agreement to Terms</Heading>
+      <P>
+        By accessing or using {projectName}, you agree to be bound by these
+        Terms and Conditions and our{" "}
+        <a
+          href="/privacy"
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          Privacy Policy
+        </a>
+        . If you do not agree to these terms, please do not use our services.
+      </P>
 
-        <Heading level={3}>2. Description of Service</Heading>
-        <P>
-          {/* Update this section to describe your specific product or service */}
-          {projectName} provides [describe your product or service here].
-          Explain the core functionality and value proposition to your users.
-        </P>
-        <List>
-          {/* Update with your actual service tiers or offerings */}
-          <li>
-            <strong>Free Plan</strong> — Describe what's included in your free
-            tier
-          </li>
-          <li>
-            <strong>Paid Plan</strong> — Describe what's included in your paid
-            tier(s)
-          </li>
-        </List>
+      <Heading level={3}>2. Description of Service</Heading>
+      <P>
+        {/* Update this section to describe your specific product or service */}
+        {projectName} provides [describe your product or service here]. Explain
+        the core functionality and value proposition to your users.
+      </P>
+      <List>
+        {/* Update with your actual service tiers or offerings */}
+        <li>
+          <strong>Free Plan</strong> — Describe what's included in your free
+          tier
+        </li>
+        <li>
+          <strong>Paid Plan</strong> — Describe what's included in your paid
+          tier(s)
+        </li>
+      </List>
 
-        <Heading level={3}>3. User Accounts</Heading>
-        <P>
-          To access certain features, you may be required to create an account.
-          You are responsible for:
-        </P>
-        <List>
-          <li>Maintaining the confidentiality of your account credentials</li>
-          <li>All activities that occur under your account</li>
-          <li>
-            Notifying us immediately of any unauthorized use of your account
-          </li>
-        </List>
+      <Heading level={3}>3. User Accounts</Heading>
+      <P>
+        To access certain features, you may be required to create an account.
+        You are responsible for:
+      </P>
+      <List>
+        <li>Maintaining the confidentiality of your account credentials</li>
+        <li>All activities that occur under your account</li>
+        <li>
+          Notifying us immediately of any unauthorized use of your account
+        </li>
+      </List>
 
-        <Heading level={3}>4. Payments and Refunds</Heading>
-        <P>
-          {/* Update this section based on your pricing model */}
-          If you purchase a paid plan, payment is processed through our payment
-          provider. By completing a purchase, you agree to:
-        </P>
-        <List>
-          <li>Pay the applicable fee as displayed at the time of purchase</li>
-          <li>Provide accurate and complete billing information</li>
-        </List>
-        <P>
-          {/* Update with your refund policy */}
-          Refunds are handled on a case-by-case basis. If you are not satisfied
-          with your purchase, please contact us at{" "}
-          <a
-            href={`mailto:${supportEmail}`}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {supportEmail}
-          </a>{" "}
-          within [X] days of purchase to discuss your options.
-        </P>
+      <Heading level={3}>4. Payments and Refunds</Heading>
+      <P>
+        {/* Update this section based on your pricing model */}
+        If you purchase a paid plan, payment is processed through our payment
+        provider. By completing a purchase, you agree to:
+      </P>
+      <List>
+        <li>Pay the applicable fee as displayed at the time of purchase</li>
+        <li>Provide accurate and complete billing information</li>
+      </List>
+      <P>
+        {/* Update with your refund policy */}
+        Refunds are handled on a case-by-case basis. If you are not satisfied
+        with your purchase, please contact us at{" "}
+        <a
+          href={`mailto:${supportEmail}`}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {supportEmail}
+        </a>{" "}
+        within [X] days of purchase to discuss your options.
+      </P>
 
-        <Heading level={3}>5. Third-Party Services</Heading>
-        <P>
-          {projectName} may integrate with third-party services. Your use of
-          these services is subject to their respective terms of service and
-          privacy policies. {projectName} is not responsible for the
-          availability, functionality, or policies of third-party services.
-        </P>
-        <List>
-          {/* Update with your actual third-party integrations */}
-          <li>
-            <strong>[Service Name]</strong> — [Description of how it's used]
-          </li>
-          <li>
-            <strong>[Service Name]</strong> — [Description of how it's used]
-          </li>
-        </List>
+      <Heading level={3}>5. Third-Party Services</Heading>
+      <P>
+        {projectName} may integrate with third-party services. Your use of these
+        services is subject to their respective terms of service and privacy
+        policies. {projectName} is not responsible for the availability,
+        functionality, or policies of third-party services.
+      </P>
+      <List>
+        {/* Update with your actual third-party integrations */}
+        <li>
+          <strong>[Service Name]</strong> — [Description of how it's used]
+        </li>
+        <li>
+          <strong>[Service Name]</strong> — [Description of how it's used]
+        </li>
+      </List>
 
-        <Heading level={3}>6. Acceptable Use</Heading>
-        <P>You agree not to use {projectName} to:</P>
-        <List>
-          <li>Violate any applicable laws or regulations</li>
-          <li>Infringe upon the intellectual property rights of others</li>
-          <li>Distribute malware, viruses, or other harmful code</li>
-          <li>
-            Engage in any activity that disrupts or interferes with our services
-          </li>
-          <li>Harass, abuse, or harm other users</li>
-        </List>
+      <Heading level={3}>6. Acceptable Use</Heading>
+      <P>You agree not to use {projectName} to:</P>
+      <List>
+        <li>Violate any applicable laws or regulations</li>
+        <li>Infringe upon the intellectual property rights of others</li>
+        <li>Distribute malware, viruses, or other harmful code</li>
+        <li>
+          Engage in any activity that disrupts or interferes with our services
+        </li>
+        <li>Harass, abuse, or harm other users</li>
+      </List>
 
-        <Heading level={3}>7. Intellectual Property</Heading>
-        <P>
-          The {projectName} brand, logo, and content are owned by us and are
-          protected by intellectual property laws. You may not use our
-          trademarks without prior written permission.
-        </P>
-        <P>
-          {/* Update based on your business model */}
-          Content you create using {projectName} belongs to you. You retain full
-          ownership of your data and any content you produce through our
-          service.
-        </P>
+      <Heading level={3}>7. Intellectual Property</Heading>
+      <P>
+        The {projectName} brand, logo, and content are owned by us and are
+        protected by intellectual property laws. You may not use our trademarks
+        without prior written permission.
+      </P>
+      <P>
+        {/* Update based on your business model */}
+        Content you create using {projectName} belongs to you. You retain full
+        ownership of your data and any content you produce through our service.
+      </P>
 
-        <Heading level={3}>8. Disclaimer of Warranties</Heading>
-        <P>
-          {projectName} is provided "as is" and "as available" without
-          warranties of any kind, either express or implied. We do not warrant
-          that:
-        </P>
-        <List>
-          <li>The service will be error-free or uninterrupted</li>
-          <li>The service will meet your specific requirements</li>
-          <li>Any defects will be corrected</li>
-        </List>
+      <Heading level={3}>8. Disclaimer of Warranties</Heading>
+      <P>
+        {projectName} is provided "as is" and "as available" without warranties
+        of any kind, either express or implied. We do not warrant that:
+      </P>
+      <List>
+        <li>The service will be error-free or uninterrupted</li>
+        <li>The service will meet your specific requirements</li>
+        <li>Any defects will be corrected</li>
+      </List>
 
-        <Heading level={3}>9. Limitation of Liability</Heading>
-        <P>
-          To the maximum extent permitted by law, {projectName} and its
-          affiliates shall not be liable for any indirect, incidental, special,
-          consequential, or punitive damages arising out of or in connection
-          with your use of the service, including but not limited to loss of
-          profits, data, business opportunities, or revenue.
-        </P>
+      <Heading level={3}>9. Limitation of Liability</Heading>
+      <P>
+        To the maximum extent permitted by law, {projectName} and its affiliates
+        shall not be liable for any indirect, incidental, special,
+        consequential, or punitive damages arising out of or in connection with
+        your use of the service, including but not limited to loss of profits,
+        data, business opportunities, or revenue.
+      </P>
 
-        <Heading level={3}>10. Support</Heading>
-        <P>
-          We provide documentation and support resources to help you use{" "}
-          {projectName}. While we strive to be helpful, we do not guarantee
-          response times or resolution of specific issues. For support
-          inquiries, contact us at{" "}
-          <a
-            href={`mailto:${supportEmail}`}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {supportEmail}
-          </a>
-          .
-        </P>
+      <Heading level={3}>10. Support</Heading>
+      <P>
+        We provide documentation and support resources to help you use{" "}
+        {projectName}. While we strive to be helpful, we do not guarantee
+        response times or resolution of specific issues. For support inquiries,
+        contact us at{" "}
+        <a
+          href={`mailto:${supportEmail}`}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {supportEmail}
+        </a>
+        .
+      </P>
 
-        <Heading level={3}>11. Termination</Heading>
-        <P>
-          We may suspend or terminate your access to {projectName} at any time
-          for violation of these terms or for any other reason at our sole
-          discretion. You may also terminate your account at any time by
-          contacting us.
-        </P>
+      <Heading level={3}>11. Termination</Heading>
+      <P>
+        We may suspend or terminate your access to {projectName} at any time for
+        violation of these terms or for any other reason at our sole discretion.
+        You may also terminate your account at any time by contacting us.
+      </P>
 
-        <Heading level={3}>12. Changes to Terms</Heading>
-        <P>
-          We reserve the right to modify these terms at any time. We will notify
-          users of material changes by posting the updated terms on{" "}
-          <a
-            href={websiteUrl}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {websiteUrl}
-          </a>
-          . Your continued use of {projectName} after such changes constitutes
-          acceptance of the new terms.
-        </P>
+      <Heading level={3}>12. Changes to Terms</Heading>
+      <P>
+        We reserve the right to modify these terms at any time. We will notify
+        users of material changes by posting the updated terms on{" "}
+        <a
+          href={websiteUrl}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {websiteUrl}
+        </a>
+        . Your continued use of {projectName} after such changes constitutes
+        acceptance of the new terms.
+      </P>
 
-        <Heading level={3}>13. Governing Law</Heading>
-        <P>
-          {/* Update with your jurisdiction */}
-          These Terms and Conditions shall be governed by and construed in
-          accordance with the laws of [Your Jurisdiction], without regard to its
-          conflict of law provisions.
-        </P>
+      <Heading level={3}>13. Governing Law</Heading>
+      <P>
+        {/* Update with your jurisdiction */}
+        These Terms and Conditions shall be governed by and construed in
+        accordance with the laws of [Your Jurisdiction], without regard to its
+        conflict of law provisions.
+      </P>
 
-        <Heading level={3}>14. Contact Us</Heading>
-        <P>
-          If you have any questions about these Terms and Conditions, please
-          contact us at{" "}
-          <a
-            href={`mailto:${supportEmail}`}
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
-          >
-            {supportEmail}
-          </a>
-          .
-        </P>
-      </div>
-    </Section>
+      <Heading level={3}>14. Contact Us</Heading>
+      <P>
+        If you have any questions about these Terms and Conditions, please
+        contact us at{" "}
+        <a
+          href={`mailto:${supportEmail}`}
+          className="text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          {supportEmail}
+        </a>
+        .
+      </P>
+    </ProseArticle>
   )
 }


### PR DESCRIPTION
## Summary
- Add `ProseArticle` component for read-based pages with centered title and prose-width content column
- Migrate privacy and terms routes from `Section` to `ProseArticle`
- Reuse `ProseArticle` in blog post route to replace duplicated layout classes

## Test plan
- [ ] Verify privacy and terms pages render with centered title and readable body text
- [ ] Verify blog post page layout is unchanged
- [ ] Run `bun run test apps/brand/components/prose-article/prose-article.test.tsx`


Made with [Cursor](https://cursor.com)