### PR TITLE
refactor(cloudflare): extract turnstile into shared package

### DIFF
--- a/apps/auth/auth.server.ts
+++ b/apps/auth/auth.server.ts
@@ -51,32 +51,3 @@ export function isOTPExpired(expiresAt: number) {
   const now = new Date()
   return now.getTime() > expiresAt
 }
-
-export async function verifyHuman({
-  secret,
-  token,
-  ip,
-}: {
-  secret: string
-  token?: string
-  ip?: string | null
-}) {
-  const body = new FormData()
-  body.append("secret", secret)
-  body.append("response", token ?? "")
-  body.append("remoteip", ip ?? "")
-
-  const result = await fetch(
-    "https://challenges.cloudflare.com/turnstile/v0/siteverify",
-    {
-      method: "POST",
-      body,
-    },
-  )
-
-  const outcome = await result.json<{ success: boolean }>()
-  if (outcome.success) {
-    return true
-  }
-  return false
-}

--- a/apps/auth/routes/login.tsx
+++ b/apps/auth/routes/login.tsx
@@ -2,13 +2,13 @@ import { useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { z } from "zod"
 import { SignIn } from "@/auth/components/sign-in"
-import { VerifyHuman } from "@/auth/components/verify-human"
 import {
   getLoginPageData,
   loginFormAction,
   loginFormSchema,
   requireGuestUser,
 } from "@/auth/rpc"
+import { Turnstile } from "@/cloudflare/turnstile"
 import { useFormAction } from "@/form"
 import { Link as UiLink } from "@/ui/link"
 
@@ -65,7 +65,7 @@ function Login() {
           expiresAt={expiresAt}
         />
         {cloudflareTurnstilePublicKey && (
-          <VerifyHuman
+          <Turnstile
             siteKey={cloudflareTurnstilePublicKey}
             subjectKey={turnstileSubjectKey}
           />

--- a/apps/auth/rpc/login.ts
+++ b/apps/auth/rpc/login.ts
@@ -3,6 +3,7 @@ import { redirect } from "@tanstack/react-router"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeader } from "@tanstack/react-start/server"
 import { z } from "zod"
+import { validateTurnstile } from "@/cloudflare/turnstile"
 import { sendAuthOtpEmail } from "@/email/templates.server"
 import { parseFormData } from "@/form"
 import {
@@ -11,7 +12,6 @@ import {
   getRedirectUrl,
   isOTPExpired,
   signOtp,
-  verifyHuman,
   verifyOtp,
 } from "../auth.server"
 import { updateAppSession } from "../session.server"
@@ -54,7 +54,7 @@ export const loginFormAction = createServerFn({ method: "POST" })
     const cloudflareTurnstileSecretKey = env.CLOUDFLARE_TURNSTILE_SECRET_KEY
     if (cloudflareTurnstileSecretKey) {
       const ip = getRequestHeader("CF-Connecting-IP")
-      const isHuman = await verifyHuman({
+      const isHuman = await validateTurnstile({
         secret: cloudflareTurnstileSecretKey,
         token: turnstileResponse,
         ip,

--- a/packages/cloudflare/turnstile/index.ts
+++ b/packages/cloudflare/turnstile/index.ts
@@ -1,0 +1,2 @@
+export { Turnstile } from "./turnstile"
+export { validateTurnstile } from "./validate-turnstile.server"

--- a/packages/cloudflare/turnstile/turnstile.tsx
+++ b/packages/cloudflare/turnstile/turnstile.tsx
@@ -10,12 +10,12 @@ declare global {
   }
 }
 
-interface VerifyHumanProps {
+interface TurnstileProps {
   siteKey: string
   subjectKey?: string
 }
 
-export const VerifyHuman = ({ siteKey, subjectKey }: VerifyHumanProps) => {
+export const Turnstile = ({ siteKey, subjectKey }: TurnstileProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isLoaded, setIsLoaded] = useState(false)
 

--- a/packages/cloudflare/turnstile/validate-turnstile.server.ts
+++ b/packages/cloudflare/turnstile/validate-turnstile.server.ts
@@ -1,0 +1,28 @@
+export async function validateTurnstile({
+  secret,
+  token,
+  ip,
+}: {
+  secret: string
+  token?: string
+  ip?: string | null
+}) {
+  const body = new FormData()
+  body.append("secret", secret)
+  body.append("response", token ?? "")
+  body.append("remoteip", ip ?? "")
+
+  const result = await fetch(
+    "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+    {
+      method: "POST",
+      body,
+    },
+  )
+
+  const outcome = await result.json<{ success: boolean }>()
+  if (outcome.success) {
+    return true
+  }
+  return false
+}


### PR DESCRIPTION
## Summary
- Move Turnstile server validation and client widget from `apps/auth` into `packages/cloudflare/turnstile`
- Rename `verifyHuman` to `validateTurnstile` and `VerifyHuman` to `Turnstile`
- Update login flow imports to use the new shared package

## Test plan
- [ ] `bun run check:types`
- [ ] `bun run check`
- [ ] Verify login page renders Turnstile widget when `CLOUDFLARE_TURNSTILE_PUBLIC_KEY` is set
- [ ] Verify login form rejects submissions when Turnstile validation fails


Made with [Cursor](https://cursor.com)