### PR TITLE
perf(turnstile): lazy-render widget when in viewport

### DIFF
--- a/packages/cloudflare/turnstile/turnstile.tsx
+++ b/packages/cloudflare/turnstile/turnstile.tsx
@@ -1,3 +1,4 @@
+import { useInView } from "motion/react"
 import { useEffect, useRef, useState } from "react"
 
 declare global {
@@ -12,15 +13,16 @@ declare global {
 
 interface TurnstileProps {
   siteKey: string
+  /** When this changes, the widget is torn down and re-rendered */
   subjectKey?: string
 }
 
 export const Turnstile = ({ siteKey, subjectKey }: TurnstileProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isLoaded, setIsLoaded] = useState(false)
+  const isInView = useInView(containerRef, { once: true, margin: "-80px" })
 
   // Load the turnstile script
-  // biome-ignore lint/correctness/useExhaustiveDependencies: executing effect on siteKey change is expected
   useEffect(() => {
     const script = document.createElement("script")
     script.src =
@@ -40,24 +42,26 @@ export const Turnstile = ({ siteKey, subjectKey }: TurnstileProps) => {
         script.parentNode.removeChild(script)
       }
     }
-  }, [siteKey])
+  }, [])
 
-  // Render the turnstile widget
-  // biome-ignore lint/correctness/useExhaustiveDependencies: executing effect on siteKey, subjectKey, isLoaded change is expected
+  // Render the turnstile widget once the script is ready and the placeholder is in view
+  // biome-ignore lint/correctness/useExhaustiveDependencies: executing effect on siteKey, subjectKey, isLoaded, isInView change is expected
   useEffect(() => {
     const ref = containerRef.current
-    if (isLoaded && ref) {
-      window.turnstile?.render(ref, {
-        sitekey: siteKey,
-      })
+    if (!isLoaded || !isInView || !ref) {
+      return
     }
+
+    window.turnstile?.render(ref, {
+      sitekey: siteKey,
+    })
 
     return () => {
       if (ref?.hasChildNodes()) {
         ref.replaceChildren()
       }
     }
-  }, [siteKey, subjectKey, isLoaded])
+  }, [siteKey, subjectKey, isLoaded, isInView])
 
   return <div ref={containerRef} />
 }


### PR DESCRIPTION
## Summary
- Defer Turnstile widget rendering until the placeholder scrolls into view using `useInView`
- Load the Turnstile API script once per mount instead of re-fetching on `siteKey` changes
- Document `subjectKey` behavior and align render effect structure with the website `verify-human` component

## Test plan
- [ ] Open `/login` with Turnstile enabled and confirm the widget appears after scrolling into view
- [ ] Submit the login form and verify the widget resets when `subjectKey` changes between pending/idle
- [ ] Confirm no duplicate Turnstile scripts are injected on re-renders


Made with [Cursor](https://cursor.com)