### PR TITLE
refactor(email): replace resend sdk with rest api

### DIFF
--- a/apps/auth/rpc/login.ts
+++ b/apps/auth/rpc/login.ts
@@ -74,7 +74,7 @@ export const loginFormAction = createServerFn({ method: "POST" })
         expiresAt: generatedExpiresAt,
       })
       try {
-        await sendAuthOtpEmail({ to: email, otp: generatedOtp, env })
+        await sendAuthOtpEmail({ to: email, otp: generatedOtp })
       } catch {
         throw new Error("Failed to send an email")
       }

--- a/apps/email/email.server.ts
+++ b/apps/email/email.server.ts
@@ -1,5 +1,6 @@
+import { env } from "cloudflare:workers"
 import { render } from "react-email"
-import { Resend } from "resend"
+import config from "@/config"
 
 export type EmailConfig = {
   email: {
@@ -15,42 +16,49 @@ export interface DevelopmentEmailPayload {
 export const developmentMailsSent: DevelopmentEmailPayload[] = []
 
 interface SendOptions {
-  from: string
+  from?: string
   to: string | string[]
   subject: string
   react: React.ReactNode
-  resendApiKey?: string
+}
+
+interface SendEmailResponse {
+  id: string
 }
 
 export async function sendEmail({
-  from,
+  from = config.email.from,
   to,
   subject,
   react,
-  resendApiKey,
-}: SendOptions) {
+}: SendOptions): Promise<SendEmailResponse> {
+  const resendApiKey = env.RESEND_API_KEY
+
   if (!resendApiKey) {
     if (import.meta.env.PROD) {
-      throw new Error("resendApiKey is not given")
+      throw new Error("RESEND_API_KEY is not set")
     }
     const body = await render(react, { plainText: true })
     const content = `From: ${from}\nTo: ${Array.isArray(to) ? to.join(", ") : to}\nSubject: ${subject}\nBody:\n${body}`
     console.log("An attempt to send an email")
     console.log(content)
     developmentMailsSent.push({ from, to, subject, body })
-    return
+    return { id: "development" }
   }
-  const resend = new Resend(resendApiKey)
-  const { data, error } = await resend.emails.send({
-    from,
-    to,
-    subject,
-    react,
+  const html = await render(react)
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ from, to, subject, html }),
   })
 
-  if (error) {
-    throw new Error(error.message)
+  if (!response.ok) {
+    throw new Error(`Failed to send email (${response.status})`)
   }
 
-  return data
+  return response.json()
 }

--- a/apps/email/templates.server.tsx
+++ b/apps/email/templates.server.tsx
@@ -1,70 +1,49 @@
-import config from "@/config"
 import { sendEmail } from "./email.server"
 import AccessFailureEmail from "./templates/access.failure"
 import AccessGrantedEmail from "./templates/access.granted"
 import AccessRevokedEmail from "./templates/access.revoked"
 import AuthOtpEmail from "./templates/auth-otp"
 
-export function sendAuthOtpEmail({
-  to,
-  otp,
-  env,
-}: {
-  to: string
-  otp: string
-  env: Env
-}) {
+export function sendAuthOtpEmail({ to, otp }: { to: string; otp: string }) {
   return sendEmail({
-    from: config.email.from,
     to,
     subject: "Temporary Password",
     react: <AuthOtpEmail otp={otp} />,
-    resendApiKey: env.RESEND_API_KEY,
   })
 }
 
-export function sendAccessFailureEmail({ to, env }: { to: string; env: Env }) {
+export function sendAccessFailureEmail({ to }: { to: string }) {
   return sendEmail({
-    from: config.email.from,
     to,
     subject: "Access failed",
     react: <AccessFailureEmail />,
-    resendApiKey: env.RESEND_API_KEY,
   })
 }
 
 export function sendAccessRevokedEmail({
   to,
-  env,
   productName,
 }: {
   to: string
-  env: Env
   productName: string
 }) {
   return sendEmail({
-    from: config.email.from,
     to,
     subject: "Access revoked",
     react: <AccessRevokedEmail productName={productName} />,
-    resendApiKey: env.RESEND_API_KEY,
   })
 }
 
 export function sendAccessGrantedEmail({
   to,
-  env,
   productName,
 }: {
   to: string
-  env: Env
   productName: string
 }) {
   return sendEmail({
-    from: config.email.from,
     to,
     subject: "Access granted",
     react: <AccessGrantedEmail productName={productName} />,
-    resendApiKey: env.RESEND_API_KEY,
   })
 }

--- a/apps/payments/handlers.server.ts
+++ b/apps/payments/handlers.server.ts
@@ -15,7 +15,6 @@ import type {
 
 export async function onPaymentSuccess(
   event: WebhookOrderPaidPayload | WebhookSubscriptionActivePayload,
-  env: Env,
 ) {
   try {
     const productId = event.data.productId
@@ -36,7 +35,6 @@ export async function onPaymentSuccess(
     await grantUserRole(user.id, userRoleToGrant)
     await sendAccessGrantedEmail({
       to: user.email,
-      env,
       productName: productConfig.name,
     })
     return new Response("Payment success", { status: 201 })
@@ -48,7 +46,6 @@ export async function onPaymentSuccess(
       if (error.message === "Product not found") {
         await sendAccessFailureEmail({
           to: event.data.customer.email,
-          env,
         })
         return new Response(error.message, { status: 200 })
       }
@@ -59,7 +56,6 @@ export async function onPaymentSuccess(
 
 export async function onPaymentRevoked(
   event: WebhookOrderRefundedPayload | WebhookSubscriptionRevokedPayload,
-  env: Env,
 ) {
   try {
     const productId = event.data.productId
@@ -80,7 +76,6 @@ export async function onPaymentRevoked(
     await revokeUserRole(user.id, userRoleToRevoke)
     await sendAccessRevokedEmail({
       to: user.email,
-      env,
       productName: productConfig.name,
     })
     return new Response("Payment revoked", { status: 201 })

--- a/apps/payments/routes/webhook.test.ts
+++ b/apps/payments/routes/webhook.test.ts
@@ -194,7 +194,6 @@ describe("Webhook", () => {
       expect(await hasUserRole(user.id, "pro" as unknown as Role)).toBe(true)
       expect(sendAccessGrantedEmail).toHaveBeenCalledWith({
         to: "new@example.com",
-        env: { POLAR_WEBHOOK_SECRET: "test" },
         productName: "Pro",
       })
     })
@@ -224,7 +223,6 @@ describe("Webhook", () => {
       expect(response.status).toBe(201)
       expect(sendAccessGrantedEmail).toHaveBeenCalledWith({
         to: "existing@example.com",
-        env: { POLAR_WEBHOOK_SECRET: "test" },
         productName: "Pro",
       })
     })
@@ -273,7 +271,6 @@ describe("Webhook", () => {
       expect(await response.text()).toBe("Product not found")
       expect(sendAccessFailureEmail).toHaveBeenCalledWith({
         to: "existing@example.com",
-        env: { POLAR_WEBHOOK_SECRET: "test" },
       })
     })
   })
@@ -305,7 +302,6 @@ describe("Webhook", () => {
       )
       expect(sendAccessRevokedEmail).toHaveBeenCalledWith({
         to: "existing@example.com",
-        env: { POLAR_WEBHOOK_SECRET: "test" },
         productName: "Pro",
       })
     })

--- a/apps/payments/routes/webhook.ts
+++ b/apps/payments/routes/webhook.ts
@@ -30,10 +30,10 @@ export const Route = createFileRoute("/payments/webhook")({
           switch (event.type) {
             case "order.paid":
             case "subscription.active":
-              return onPaymentSuccess(event, env)
+              return onPaymentSuccess(event)
             case "order.refunded":
             case "subscription.revoked":
-              return onPaymentRevoked(event, env)
+              return onPaymentRevoked(event)
             default:
               return new Response("Event not handled", { status: 202 })
           }

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,6 @@
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-email": "6.1.1",
-        "resend": "6.10.0",
         "tailwind-merge": "3.5.0",
         "zod": "4.1.12",
       },
@@ -1373,8 +1372,6 @@
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
-    "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
-
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
@@ -1448,8 +1445,6 @@
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "resend": ["resend@6.10.0", "", { "dependencies": { "postal-mime": "2.7.4", "svix": "1.88.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q=="],
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
@@ -1551,8 +1546,6 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "svix": ["svix@1.88.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw=="],
-
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
@@ -1636,8 +1629,6 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-email": "6.1.1",
-    "resend": "6.10.0",
     "tailwind-merge": "3.5.0",
     "zod": "4.1.12"
   },


### PR DESCRIPTION
## Summary
- Replace the `resend` SDK with a direct call to the Resend REST API
- Default the sender address from `config.email.from` and read `RESEND_API_KEY` from `cloudflare:workers`
- Simplify email template helpers and payment webhook handlers by removing redundant `env` and `from` parameters
- Remove the `resend` dependency

## Test plan
- [x] `bun run check:types`
- [x] `bun run test apps/payments/routes/webhook.test.ts`
- [x] Verify OTP email flow in local dev (no API key — logs to console)
- [x] Verify email sending in preview/production with `RESEND_API_KEY` set


Made with [Cursor](https://cursor.com)