### PR TITLE
refactor(crypto,email): simplify signing and restore resend sdk

### DIFF
--- a/apps/auth/auth.server.ts
+++ b/apps/auth/auth.server.ts
@@ -1,33 +1,6 @@
-import { sign, verify } from "@/crypto"
-
-type OTPPayload = {
-  email: string
-  otp: string
-  expiresAt: number
-}
-
 export function getRedirectUrl(redirectTo: string = "/") {
   const requestURLObject = new URL(redirectTo, "https://base")
   return requestURLObject.pathname + requestURLObject.search
-}
-
-export async function signOtp(
-  secret: string,
-  { email, otp, expiresAt }: OTPPayload,
-) {
-  const data = JSON.stringify({ email, otp, expiresAt })
-  const signature = await sign(secret, data)
-  return signature
-}
-
-export async function verifyOtp(
-  secret: string,
-  { email, otp, expiresAt }: OTPPayload,
-  signature: string,
-) {
-  const data = JSON.stringify({ email, otp, expiresAt })
-  const isValid = await verify(secret, data, signature)
-  return isValid
 }
 
 export function generateOTP() {

--- a/apps/auth/rpc/login.ts
+++ b/apps/auth/rpc/login.ts
@@ -4,6 +4,7 @@ import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeader } from "@tanstack/react-start/server"
 import { z } from "zod"
 import { validateTurnstile } from "@/cloudflare/turnstile"
+import { sign, verify } from "@/crypto"
 import { sendAuthOtpEmail } from "@/email/templates.server"
 import { parseFormData } from "@/form"
 import {
@@ -11,8 +12,6 @@ import {
   generateOTPExpiration,
   getRedirectUrl,
   isOTPExpired,
-  signOtp,
-  verifyOtp,
 } from "../auth.server"
 import { updateAppSession } from "../session.server"
 import { getOrCreateUserByEmail } from "../user.server"
@@ -68,7 +67,7 @@ export const loginFormAction = createServerFn({ method: "POST" })
     if (!otp) {
       const generatedOtp = generateOTP()
       const generatedExpiresAt = generateOTPExpiration()
-      const generatedSignature = await signOtp(env.OTP_SECRET, {
+      const generatedSignature = await sign(env.OTP_SECRET, {
         email,
         otp: generatedOtp,
         expiresAt: generatedExpiresAt,
@@ -87,7 +86,7 @@ export const loginFormAction = createServerFn({ method: "POST" })
       }
     }
 
-    const isValid = await verifyOtp(
+    const isValid = await verify(
       env.OTP_SECRET,
       {
         email,

--- a/apps/email/email.server.ts
+++ b/apps/email/email.server.ts
@@ -1,5 +1,6 @@
 import { env } from "cloudflare:workers"
 import { render } from "react-email"
+import { Resend } from "resend"
 import config from "@/config"
 
 export type EmailConfig = {
@@ -45,20 +46,21 @@ export async function sendEmail({
     developmentMailsSent.push({ from, to, subject, body })
     return { id: "development" }
   }
-  const html = await render(react)
-
-  const response = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${resendApiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ from, to, subject, html }),
+  const resend = new Resend(resendApiKey)
+  const { data, error } = await resend.emails.send({
+    from,
+    to,
+    subject,
+    react,
   })
 
-  if (!response.ok) {
-    throw new Error(`Failed to send email (${response.status})`)
+  if (error) {
+    throw new Error(error.message)
   }
 
-  return response.json()
+  if (!data) {
+    throw new Error("Failed to send email")
+  }
+
+  return data
 }

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-email": "6.1.1",
+        "resend": "6.10.0",
         "tailwind-merge": "3.5.0",
         "zod": "4.1.12",
       },
@@ -1372,6 +1373,8 @@
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
+    "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
@@ -1445,6 +1448,8 @@
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resend": ["resend@6.10.0", "", { "dependencies": { "postal-mime": "2.7.4", "svix": "1.88.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q=="],
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
@@ -1546,6 +1551,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "svix": ["svix@1.88.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw=="],
+
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
@@ -1629,6 +1636,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-email": "6.1.1",
+    "resend": "6.10.0",
     "tailwind-merge": "3.5.0",
     "zod": "4.1.12"
   },

--- a/packages/crypto/crypto.server.test.ts
+++ b/packages/crypto/crypto.server.test.ts
@@ -3,7 +3,7 @@ import { sign, verify } from "./crypto.server"
 
 describe("crypto", () => {
   const testSecret = "test-secret-key"
-  const testData = "hello world"
+  const testData = { message: "hello world" }
 
   it("signs and verifies data", async () => {
     const signature = await sign(testSecret, testData)
@@ -19,7 +19,11 @@ describe("crypto", () => {
 
   it("fails verification if the data is invalid", async () => {
     const signature = await sign(testSecret, testData)
-    const isValid = await verify(testSecret, "invalid-data", signature)
+    const isValid = await verify(
+      testSecret,
+      { message: "invalid-data" },
+      signature,
+    )
     expect(isValid).toBe(false)
   })
 

--- a/packages/crypto/crypto.server.ts
+++ b/packages/crypto/crypto.server.ts
@@ -44,32 +44,32 @@ function hashToArrayBuffer(hash: string): ArrayBuffer {
 }
 
 /**
- * Creates an HMAC signature for the provided data using the given secret.
+ * Creates an HMAC signature for the provided JSON payload using the given secret.
  *
  * @param secret - The secret key used for signing
- * @param data - The string data to sign
+ * @param data - The JSON-serializable payload to sign
  * @returns A hash string representation of the signature
  */
-export async function sign(secret: string, data: string) {
+export async function sign<T>(secret: string, data: T) {
   const key = await createKey(secret, ["sign"])
   const encoder = new TextEncoder()
   const signatureBuffer = await crypto.subtle.sign(
     "HMAC",
     key,
-    encoder.encode(data),
+    encoder.encode(JSON.stringify(data)),
   )
   return arrayBufferToHash(signatureBuffer)
 }
 
 /**
- * Verifies if a signature is valid for the given data and secret.
+ * Verifies if a signature is valid for the given JSON payload and secret.
  *
  * @param secret - The secret key that was used for signing
- * @param data - The string data that was signed
+ * @param data - The JSON-serializable payload that was signed
  * @param signature - The hash string signature to verify
  * @returns A boolean indicating whether the signature is valid
  */
-export async function verify(secret: string, data: string, signature: string) {
+export async function verify<T>(secret: string, data: T, signature: string) {
   const key = await createKey(secret, ["verify"])
   const encoder = new TextEncoder()
   let signatureBuffer: ArrayBuffer
@@ -82,6 +82,6 @@ export async function verify(secret: string, data: string, signature: string) {
     "HMAC",
     key,
     signatureBuffer,
-    encoder.encode(data),
+    encoder.encode(JSON.stringify(data)),
   )
 }


### PR DESCRIPTION
## Summary
- Update `sign` and `verify` in `@/crypto` to accept JSON-serializable payloads and stringify internally
- Remove redundant `signOtp` and `verifyOtp` wrappers from auth and use crypto helpers directly in login
- Restore the Resend SDK for production email sending instead of direct REST API calls

## Test plan
- [x] `bun run test packages/crypto/crypto.server.test.ts apps/auth/auth.server.test.ts`
- [x] `bun run check:types`


Made with [Cursor](https://cursor.com)