### PR TITLE
refactor(date): extract shared date utilities

### DIFF
--- a/apps/auth/auth.server.ts
+++ b/apps/auth/auth.server.ts
@@ -13,14 +13,3 @@ export function generateOTP() {
   // convert to string and ensure it's exactly 6 digits by padding with leading zeros if needed
   return otp.toString().padStart(6, "0")
 }
-
-export function generateOTPExpiration(minutesOffset: number = 5) {
-  const now = new Date()
-  now.setMinutes(now.getMinutes() + minutesOffset)
-  return now.getTime()
-}
-
-export function isOTPExpired(expiresAt: number) {
-  const now = new Date()
-  return now.getTime() > expiresAt
-}

--- a/apps/auth/rpc/login.ts
+++ b/apps/auth/rpc/login.ts
@@ -5,14 +5,10 @@ import { getRequestHeader } from "@tanstack/react-start/server"
 import { z } from "zod"
 import { validateTurnstile } from "@/cloudflare/turnstile"
 import { sign, verify } from "@/crypto"
+import { expiresInMinutes, isExpired } from "@/date"
 import { sendAuthOtpEmail } from "@/email/templates.server"
 import { parseFormData } from "@/form"
-import {
-  generateOTP,
-  generateOTPExpiration,
-  getRedirectUrl,
-  isOTPExpired,
-} from "../auth.server"
+import { generateOTP, getRedirectUrl } from "../auth.server"
 import { updateAppSession } from "../session.server"
 import { getOrCreateUserByEmail } from "../user.server"
 
@@ -66,7 +62,7 @@ export const loginFormAction = createServerFn({ method: "POST" })
 
     if (!otp) {
       const generatedOtp = generateOTP()
-      const generatedExpiresAt = generateOTPExpiration()
+      const generatedExpiresAt = expiresInMinutes(5)
       const generatedSignature = await sign(env.OTP_SECRET, {
         email,
         otp: generatedOtp,
@@ -105,7 +101,7 @@ export const loginFormAction = createServerFn({ method: "POST" })
       }
     }
 
-    if (isOTPExpired(expiresAt ?? 0)) {
+    if (isExpired(expiresAt ?? 0)) {
       throw new Error("Verification code expired")
     }
 

--- a/apps/blog/components/blog-post-summary/blog-post-summary.tsx
+++ b/apps/blog/components/blog-post-summary/blog-post-summary.tsx
@@ -1,17 +1,8 @@
 import { User } from "lucide-react"
+import { formatDate } from "@/date"
 import { Link } from "@/ui/link"
 import { Heading, Muted, Small } from "@/ui/typography"
 import { cn } from "@/ui/utils"
-
-/** Stable across SSR and client; date-only frontmatter parses as UTC midnight */
-function formatBlogDate(date: Date): string {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  }).format(date)
-}
 
 interface BlogPostAuthor {
   name: string
@@ -111,7 +102,7 @@ export const BlogPostSummary = ({
           isHeader ? "mb-4 block" : "-mb-2",
         )}
       >
-        {formatBlogDate(date)}
+        {formatDate(date)}
       </time>
       <Heading
         level={isHeader ? 1 : 3}

--- a/apps/brand/routes/legal.tsx
+++ b/apps/brand/routes/legal.tsx
@@ -2,17 +2,9 @@ import { createFileRoute, notFound } from "@tanstack/react-router"
 import { ProseArticle } from "@/brand/components/prose-article"
 import { legalDocumentFrontmatterSchema, legalModules } from "@/brand/content"
 import config from "@/config"
+import { formatDate } from "@/date"
 import { getMdxModuleBySlug, MDXProvider } from "@/mdx"
 import { Muted } from "@/ui/typography"
-
-function formatLegalDate(date: Date): string {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  }).format(date)
-}
 
 export const Route = createFileRoute("/_brand-layout/legal/$slug")({
   loader: ({ params }) => {
@@ -48,7 +40,7 @@ function LegalDocument() {
 
   return (
     <ProseArticle title={document.title}>
-      <Muted>Last updated: {formatLegalDate(new Date(document.date))}</Muted>
+      <Muted>Last updated: {formatDate(new Date(document.date))}</Muted>
       <MDXProvider>
         <DocumentComponent />
       </MDXProvider>

--- a/apps/newsletter/newsletter.server.ts
+++ b/apps/newsletter/newsletter.server.ts
@@ -3,16 +3,6 @@ export type NewsletterConfirmationPayload = {
   expiresAt: number
 }
 
-export function generateExpiration(minutesOffset: number = 30) {
-  const now = new Date()
-  now.setMinutes(now.getMinutes() + minutesOffset)
-  return now.getTime()
-}
-
-export function isExpired(expiresAt: number) {
-  return Date.now() > expiresAt
-}
-
 export function buildConfirmUrl(
   baseUrl: string,
   {

--- a/apps/newsletter/rpc/confirm.ts
+++ b/apps/newsletter/rpc/confirm.ts
@@ -4,8 +4,8 @@ import { createServerFn } from "@tanstack/react-start"
 import { Resend } from "resend"
 import { z } from "zod"
 import { verify } from "@/crypto"
+import { isExpired } from "@/date"
 import { parseFormData } from "@/form"
-import { isExpired } from "../newsletter.server"
 
 export const confirmFormSchema = z.object({
   email: z.email(),

--- a/apps/newsletter/rpc/subscribe.ts
+++ b/apps/newsletter/rpc/subscribe.ts
@@ -5,9 +5,10 @@ import { z } from "zod"
 import { validateTurnstile } from "@/cloudflare/turnstile"
 import config from "@/config"
 import { sign } from "@/crypto"
+import { expiresInMinutes } from "@/date"
 import { sendNewsletterConfirmEmail } from "@/email/templates.server"
 import { parseFormData } from "@/form"
-import { buildConfirmUrl, generateExpiration } from "../newsletter.server"
+import { buildConfirmUrl } from "../newsletter.server"
 
 export const subscribeFormSchema = z.object({
   email: z.email(),
@@ -37,7 +38,7 @@ export const subscribeFormAction = createServerFn({ method: "POST" })
       }
     }
 
-    const expiresAt = generateExpiration()
+    const expiresAt = expiresInMinutes(30)
     const signature = await sign(env.OTP_SECRET, { email, expiresAt })
     const confirmUrl = buildConfirmUrl(config.core.websiteUrl, {
       email,

--- a/packages/date/expiration.test.ts
+++ b/packages/date/expiration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { expiresInMinutes, isExpired } from "./expiration"
+
+describe("expiresInMinutes", () => {
+  it("returns a timestamp offset from the given date", () => {
+    const from = new Date("2026-01-01T12:00:00.000Z")
+    expect(expiresInMinutes(30, from)).toBe(
+      new Date("2026-01-01T12:30:00.000Z").getTime(),
+    )
+  })
+})
+
+describe("isExpired", () => {
+  it("returns true when the timestamp is in the past", () => {
+    expect(isExpired(100, 200)).toBe(true)
+  })
+
+  it("returns false when the timestamp is in the future", () => {
+    expect(isExpired(200, 100)).toBe(false)
+  })
+})

--- a/packages/date/expiration.ts
+++ b/packages/date/expiration.ts
@@ -1,0 +1,15 @@
+export function expiresInMinutes(
+  minutesOffset: number,
+  from: Date = new Date(),
+): number {
+  const date = new Date(from)
+  date.setMinutes(date.getMinutes() + minutesOffset)
+  return date.getTime()
+}
+
+export function isExpired(
+  expiresAt: number,
+  now: number = Date.now(),
+): boolean {
+  return now > expiresAt
+}

--- a/packages/date/format-date.test.ts
+++ b/packages/date/format-date.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { formatDate } from "./format-date"
+
+describe("formatDate", () => {
+  it("formats a UTC date-only value", () => {
+    const date = new Date("2026-01-15T00:00:00.000Z")
+    expect(formatDate(date)).toBe("Jan 15, 2026")
+  })
+
+  it("supports custom locale and time zone", () => {
+    const date = new Date("2026-01-15T23:00:00.000Z")
+    expect(
+      formatDate(date, { locale: "en-GB", timeZone: "Europe/Warsaw" }),
+    ).toBe("16 Jan 2026")
+  })
+})

--- a/packages/date/format-date.ts
+++ b/packages/date/format-date.ts
@@ -1,0 +1,17 @@
+interface FormatDateOptions {
+  locale?: string
+  timeZone?: string
+}
+
+/** Stable across SSR and client; UTC is the default for date-only values. */
+export function formatDate(
+  date: Date,
+  { locale = "en-US", timeZone = "UTC" }: FormatDateOptions = {},
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone,
+  }).format(date)
+}

--- a/packages/date/index.ts
+++ b/packages/date/index.ts
@@ -1,0 +1,2 @@
+export * from "./expiration"
+export * from "./format-date"


### PR DESCRIPTION
## Summary
- Add `packages/date` with shared `formatDate`, `expiresInMinutes`, and `isExpired` helpers
- Replace duplicated date formatting in blog and legal pages with `formatDate`
- Replace auth and newsletter expiration helpers with the shared utilities
- Add unit tests for the new date package


Made with [Cursor](https://cursor.com)