### PR TITLE
refactor(form): reorder useFormAction and parseFormData arguments

### DIFF
--- a/apps/auth/components/sign-in/sign-in.tsx
+++ b/apps/auth/components/sign-in/sign-in.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangleIcon, InfoIcon, LockIcon } from "lucide-react"
+import { AlertTriangleIcon, InfoIcon, Loader2, LockIcon } from "lucide-react"
 import { useEffect, useId, useState } from "react"
 import { Alert, AlertDescription } from "@/ui/alert"
 import { Button } from "@/ui/button"
@@ -12,6 +12,7 @@ interface SignInProps {
   success?: string
   signature?: string
   expiresAt?: number
+  isPending?: boolean
 }
 
 export const SignIn = ({
@@ -20,6 +21,7 @@ export const SignIn = ({
   success,
   signature,
   expiresAt,
+  isPending,
 }: SignInProps) => {
   const [otp, setOtp] = useState("")
   const emailInputId = useId()
@@ -95,7 +97,8 @@ export const SignIn = ({
       </div>
 
       <div>
-        <Button type="submit" className="w-full">
+        <Button type="submit" className="w-full" disabled={isPending}>
+          {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
           {email ? "Verify" : "Login"}
         </Button>
       </div>

--- a/apps/auth/routes/login.tsx
+++ b/apps/auth/routes/login.tsx
@@ -58,6 +58,7 @@ function Login() {
       <main className="flex h-screen flex-col items-center justify-center gap-4">
         <input type="hidden" name="redirectTo" value={redirectTo} />
         <SignIn
+          isPending={isPending}
           email={email}
           error={actionError ?? error?.message}
           success={success}

--- a/apps/auth/routes/login.tsx
+++ b/apps/auth/routes/login.tsx
@@ -32,8 +32,8 @@ function Login() {
   const { cloudflareTurnstilePublicKey, redirectTo } = Route.useLoaderData()
   const queryClient = useQueryClient()
   const { data, error, isPending, onSubmit } = useFormAction(
-    loginFormAction,
     loginFormSchema,
+    loginFormAction,
     {
       onSuccess: () => {
         void queryClient.invalidateQueries({ queryKey: ["user"] })

--- a/apps/auth/rpc/login.ts
+++ b/apps/auth/rpc/login.ts
@@ -31,7 +31,7 @@ export const getLoginPageData = createServerFn({ method: "GET" })
   })
 
 export const loginFormAction = createServerFn({ method: "POST" })
-  .validator((data: FormData) => parseFormData(data, loginFormSchema))
+  .validator((data: FormData) => parseFormData(loginFormSchema, data))
   .handler(async ({ data }) => {
     if (!env.OTP_SECRET) {
       throw new Error("OTP_SECRET is not set")

--- a/apps/newsletter/components/newsletter-signup/newsletter-signup.tsx
+++ b/apps/newsletter/components/newsletter-signup/newsletter-signup.tsx
@@ -17,8 +17,8 @@ export function NewsletterSignup({
   className,
 }: NewsletterSignupProps) {
   const { data, error, isPending, onSubmit } = useFormAction(
-    subscribeFormAction,
     subscribeFormSchema,
+    subscribeFormAction,
   )
   const success = data?.success
   const turnstileSubjectKey = isPending ? "pending" : "idle"

--- a/apps/newsletter/routes/confirm.tsx
+++ b/apps/newsletter/routes/confirm.tsx
@@ -32,8 +32,8 @@ export const Route = createFileRoute("/newsletter/confirm")({
 function Confirm() {
   const { email, expiresAt, signature } = Route.useLoaderData()
   const { data, error, isPending, onSubmit } = useFormAction(
-    confirmFormAction,
     confirmFormSchema,
+    confirmFormAction,
   )
   const { success } = data || {}
 

--- a/apps/newsletter/rpc/confirm.ts
+++ b/apps/newsletter/rpc/confirm.ts
@@ -39,7 +39,7 @@ export const getConfirmPageData = createServerFn({ method: "GET" })
   })
 
 export const confirmFormAction = createServerFn({ method: "POST" })
-  .validator((data: FormData) => parseFormData(data, confirmFormSchema))
+  .validator((data: FormData) => parseFormData(confirmFormSchema, data))
   .handler(async ({ data }) => {
     if (!env.OTP_SECRET) {
       throw new Error("OTP_SECRET is not set")

--- a/apps/newsletter/rpc/subscribe.ts
+++ b/apps/newsletter/rpc/subscribe.ts
@@ -16,7 +16,7 @@ export const subscribeFormSchema = z.object({
 })
 
 export const subscribeFormAction = createServerFn({ method: "POST" })
-  .validator((data: FormData) => parseFormData(data, subscribeFormSchema))
+  .validator((data: FormData) => parseFormData(subscribeFormSchema, data))
   .handler(async ({ data }) => {
     if (!env.OTP_SECRET) {
       throw new Error("OTP_SECRET is not set")

--- a/packages/form/parse-form-data.test.ts
+++ b/packages/form/parse-form-data.test.ts
@@ -12,17 +12,16 @@ describe("parseFormData", () => {
     const formData = new FormData()
     formData.set("email", "user@example.com")
 
-    expect(parseFormData(formData, testSchema)).toEqual({
+    expect(parseFormData(testSchema, formData)).toEqual({
       email: "user@example.com",
     })
   })
 
   it("throws when data is not FormData", () => {
     expect(() =>
-      parseFormData(
-        { email: "user@example.com" } as unknown as FormData,
-        testSchema,
-      ),
+      parseFormData(testSchema, {
+        email: "user@example.com",
+      } as unknown as FormData),
     ).toThrow("Expected FormData")
   })
 
@@ -34,7 +33,7 @@ describe("parseFormData", () => {
     })
 
     try {
-      parseFormData(formData, schema)
+      parseFormData(schema, formData)
       expect.unreachable("Expected parseFormData to throw")
     } catch (error) {
       expect(error).toEqual({
@@ -55,7 +54,7 @@ describe("parseFormData", () => {
     })
 
     try {
-      parseFormData(formData, schema)
+      parseFormData(schema, formData)
       expect.unreachable("Expected parseFormData to throw")
     } catch (error) {
       expect(error).toMatchObject({

--- a/packages/form/parse-form-data.ts
+++ b/packages/form/parse-form-data.ts
@@ -4,8 +4,8 @@ import type { FormError } from "./use-form-action"
 z.config(z.locales.en())
 
 export function parseFormData<TSchema extends z.ZodType>(
-  data: FormData,
   schema: TSchema,
+  data: FormData,
 ): z.infer<TSchema> {
   if (!(data instanceof FormData)) {
     throw new TypeError("Expected FormData")

--- a/packages/form/use-form-action.test.tsx
+++ b/packages/form/use-form-action.test.tsx
@@ -30,7 +30,7 @@ function renderFormAction<TResponse = unknown>(
     defaultOptions: { mutations: { retry: false } },
   })
 
-  return renderHook(() => useFormAction(serverFn, testSchema, options), {
+  return renderHook(() => useFormAction(testSchema, serverFn, options), {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),

--- a/packages/form/use-form-action.ts
+++ b/packages/form/use-form-action.ts
@@ -26,14 +26,19 @@ type FormFields<TSchema extends z.ZodObject<z.ZodRawShape>> = {
 }
 
 type UseFormActionResult<
-  TData,
+  TResponse,
   TError,
   TSchema extends z.ZodObject<z.ZodRawShape>,
   TOnMutateResult = unknown,
-> = UseMutationResult<TData, TError, FormData, TOnMutateResult> & {
+> = UseMutationResult<TResponse, TError, FormData, TOnMutateResult> & {
   onSubmit: (event: React.SubmitEvent<HTMLFormElement>) => void
   fields: FormFields<TSchema>
 }
+
+type UseFormActionOptions<TResponse, TError, TOnMutateResult> = Omit<
+  UseMutationOptions<TResponse, TError, FormData, TOnMutateResult>,
+  "mutationFn"
+>
 
 function isFormError<TSchema extends z.ZodType>(
   error: unknown,
@@ -76,10 +81,7 @@ export function useFormAction<
 >(
   serverFn: FormActionServerFn<TResponse>,
   schema: TSchema,
-  options?: Omit<
-    UseMutationOptions<TResponse, TError, FormData, TOnMutateResult>,
-    "mutationFn"
-  >,
+  options?: UseFormActionOptions<TResponse, TError, TOnMutateResult>,
 ): UseFormActionResult<TResponse, TError, TSchema, TOnMutateResult> {
   const runServerFn = useServerFn(serverFn)
 

--- a/packages/form/use-form-action.ts
+++ b/packages/form/use-form-action.ts
@@ -4,7 +4,7 @@ import {
   useMutation,
 } from "@tanstack/react-query"
 import { useServerFn } from "@tanstack/react-start"
-import { useCallback, useMemo } from "react"
+import { useMemo } from "react"
 import type { z } from "zod"
 
 export interface FormError<TSchema extends z.ZodType> {

--- a/packages/form/use-form-action.ts
+++ b/packages/form/use-form-action.ts
@@ -46,6 +46,28 @@ function isFormError<TSchema extends z.ZodType>(
   )
 }
 
+function getFormFields<TSchema extends z.ZodObject<z.ZodRawShape>>(
+  error: unknown,
+  schema: TSchema,
+): FormFields<TSchema> {
+  const fieldErrors = isFormError<TSchema>(error) ? error.fields : undefined
+
+  const fields = Object.fromEntries(
+    Object.keys(schema.shape).map((key) => {
+      const fieldKey = key as keyof z.infer<TSchema> & string
+      return [
+        key,
+        {
+          name: fieldKey,
+          errors: fieldErrors?.[fieldKey] ?? [],
+        },
+      ]
+    }),
+  ) as FormFields<TSchema>
+
+  return fields
+}
+
 export function useFormAction<
   TResponse,
   TSchema extends z.ZodObject<z.ZodRawShape>,
@@ -72,22 +94,7 @@ export function useFormAction<
       mutation.mutate(new FormData(event.currentTarget))
     }
 
-    const fieldErrors = isFormError<TSchema>(mutation.error)
-      ? mutation.error.fields
-      : undefined
-
-    const fields = Object.fromEntries(
-      Object.keys(schema.shape).map((key) => {
-        const fieldKey = key as keyof z.infer<TSchema> & string
-        return [
-          key,
-          {
-            name: fieldKey,
-            errors: fieldErrors?.[fieldKey] ?? [],
-          },
-        ]
-      }),
-    ) as FormFields<TSchema>
+    const fields = getFormFields(mutation.error, schema)
 
     return {
       ...mutation,

--- a/packages/form/use-form-action.ts
+++ b/packages/form/use-form-action.ts
@@ -52,8 +52,8 @@ function isFormError<TSchema extends z.ZodType>(
 }
 
 function getFormFields<TSchema extends z.ZodObject<z.ZodRawShape>>(
-  error: unknown,
   schema: TSchema,
+  error: unknown,
 ): FormFields<TSchema> {
   const fieldErrors = isFormError<TSchema>(error) ? error.fields : undefined
 
@@ -79,8 +79,8 @@ export function useFormAction<
   TError = Error | FormError<TSchema>,
   TOnMutateResult = unknown,
 >(
-  serverFn: FormActionServerFn<TResponse>,
   schema: TSchema,
+  serverFn: FormActionServerFn<TResponse>,
   options?: UseFormActionOptions<TResponse, TError, TOnMutateResult>,
 ): UseFormActionResult<TResponse, TError, TSchema, TOnMutateResult> {
   const runServerFn = useServerFn(serverFn)
@@ -96,7 +96,7 @@ export function useFormAction<
       mutation.mutate(new FormData(event.currentTarget))
     }
 
-    const fields = getFormFields(mutation.error, schema)
+    const fields = getFormFields(schema, mutation.error)
 
     return {
       ...mutation,

--- a/packages/form/use-form-action.ts
+++ b/packages/form/use-form-action.ts
@@ -103,5 +103,5 @@ export function useFormAction<
       onSubmit,
       fields,
     }
-  }, [mutation, schema, mutation.error, mutation.mutate])
+  }, [mutation, schema])
 }

--- a/packages/form/use-form-action.ts
+++ b/packages/form/use-form-action.ts
@@ -66,15 +66,12 @@ export function useFormAction<
     mutationFn: (formData: FormData) => runServerFn({ data: formData }),
   })
 
-  const onSubmit = useCallback(
-    (event: React.SubmitEvent<HTMLFormElement>) => {
+  return useMemo(() => {
+    const onSubmit = (event: React.SubmitEvent<HTMLFormElement>) => {
       event.preventDefault()
       mutation.mutate(new FormData(event.currentTarget))
-    },
-    [mutation.mutate],
-  )
+    }
 
-  return useMemo(() => {
     const fieldErrors = isFormError<TSchema>(mutation.error)
       ? mutation.error.fields
       : undefined
@@ -97,5 +94,5 @@ export function useFormAction<
       onSubmit,
       fields,
     }
-  }, [mutation, onSubmit, schema, mutation.error])
+  }, [mutation, schema, mutation.error, mutation.mutate])
 }


### PR DESCRIPTION
## Summary
- Reorder `useFormAction` and `parseFormData` to accept the Zod schema before the server function / `FormData`, matching a schema-first validation flow
- Extract field error mapping into `getFormFields` and simplify `useFormAction` memoization
- Add a loading state to the login form submit button while the action is pending
- Update auth and newsletter form call sites to match the new API

## Test plan
- [ ] Run `bun run test` — form package tests pass
- [ ] Submit login form — button shows spinner and is disabled while pending
- [ ] Submit newsletter signup and confirm forms — validation errors still display on fields


Made with [Cursor](https://cursor.com)