### PR TITLE
fix(core): remove duplicate RootDocument from error and not-found pages

### DIFF
--- a/apps/root.tsx
+++ b/apps/root.tsx
@@ -64,29 +64,22 @@ function RootComponent() {
 }
 
 function RootErrorComponent({ error }: { error: unknown }) {
-  return (
-    <RootDocument>
-      <ErrorPage error={error} />
-    </RootDocument>
-  )
+  return <ErrorPage error={error} />
 }
 
 function RootNotFoundComponent() {
   return (
-    <RootDocument>
-      <ErrorPage
-        error={{
-          name: "Page not found",
-          message:
-            "The page you're looking for doesn't exist or has been moved.",
-        }}
-        action={
-          <Button asChild variant="outline">
-            <a href="/">Go home</a>
-          </Button>
-        }
-      />
-    </RootDocument>
+    <ErrorPage
+      error={{
+        name: "Page not found",
+        message: "The page you're looking for doesn't exist or has been moved.",
+      }}
+      action={
+        <Button asChild variant="outline">
+          <a href="/">Go home</a>
+        </Button>
+      }
+    />
   )
 }
 


### PR DESCRIPTION
## Summary
- Remove `RootDocument` wrapper from `RootErrorComponent` and `RootNotFoundComponent` in `apps/root.tsx`
- Prevents nested `<html>`/`<body>` shells when TanStack Router renders root-level error and not-found states

## Test plan
- [ ] Navigate to a non-existent route and confirm the 404 page renders correctly with styles and layout
- [ ] Trigger a root-level error and confirm the error page renders without duplicate document markup
- [ ] Verify normal page navigation still works as expected


Made with [Cursor](https://cursor.com)