### PR TITLE
fix(auth): validate required auth secrets on login page

### DIFF
--- a/apps/auth/routes/login.tsx
+++ b/apps/auth/routes/login.tsx
@@ -6,6 +6,7 @@ import {
   getLoginPageData,
   loginFormAction,
   loginFormSchema,
+  requireAuthConfiguration,
   requireGuestUser,
 } from "@/auth/rpc"
 import { Turnstile } from "@/cloudflare/turnstile"
@@ -19,6 +20,7 @@ const loginSearchSchema = z.object({
 export const Route = createFileRoute("/login")({
   validateSearch: (search) => loginSearchSchema.parse(search),
   beforeLoad: async () => {
+    requireAuthConfiguration()
     await requireGuestUser()
   },
   loaderDeps: ({ search }) => ({ redirectTo: search.redirectTo ?? "/" }),

--- a/apps/auth/rpc/guards.ts
+++ b/apps/auth/rpc/guards.ts
@@ -1,3 +1,4 @@
+import { env } from "cloudflare:workers"
 import { redirect } from "@tanstack/react-router"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestUrl } from "@tanstack/react-start/server"
@@ -35,3 +36,13 @@ export const requireGuestUser = createServerFn({ method: "GET" }).handler(
     }
   },
 )
+
+export const requireAuthConfiguration = createServerFn({
+  method: "GET",
+}).handler(() => {
+  if (!env.OTP_SECRET || !env.SESSION_COOKIE_SECRET) {
+    throw new Error(
+      "Authentication OTP_SECRET or SESSION_COOKIE_SECRET is not configured",
+    )
+  }
+})


### PR DESCRIPTION
## Summary
- Add `requireAuthConfiguration` server guard that checks `OTP_SECRET` and `SESSION_COOKIE_SECRET` are set
- Call the guard in the login route `beforeLoad` so misconfigured auth fails fast with a clear error

## Test plan
- [ ] Visit `/login` with auth secrets configured — page loads normally
- [ ] Visit `/login` without `OTP_SECRET` or `SESSION_COOKIE_SECRET` — error is thrown before login flow proceeds


Made with [Cursor](https://cursor.com)