### PR TITLE
fix(auth): await auth configuration guard and restore error document shell

### DIFF
--- a/apps/auth/routes/login.tsx
+++ b/apps/auth/routes/login.tsx
@@ -20,7 +20,7 @@ const loginSearchSchema = z.object({
 export const Route = createFileRoute("/login")({
   validateSearch: (search) => loginSearchSchema.parse(search),
   beforeLoad: async () => {
-    requireAuthConfiguration()
+    await requireAuthConfiguration()
     await requireGuestUser()
   },
   loaderDeps: ({ search }) => ({ redirectTo: search.redirectTo ?? "/" }),

--- a/apps/auth/rpc/guards.ts
+++ b/apps/auth/rpc/guards.ts
@@ -39,7 +39,7 @@ export const requireGuestUser = createServerFn({ method: "GET" }).handler(
 
 export const requireAuthConfiguration = createServerFn({
   method: "GET",
-}).handler(() => {
+}).handler(async () => {
   if (!env.OTP_SECRET || !env.SESSION_COOKIE_SECRET) {
     throw new Error(
       "Authentication OTP_SECRET or SESSION_COOKIE_SECRET is not configured",

--- a/apps/root.tsx
+++ b/apps/root.tsx
@@ -64,7 +64,11 @@ function RootComponent() {
 }
 
 function RootErrorComponent({ error }: { error: unknown }) {
-  return <ErrorPage error={error} />
+  return (
+    <RootDocument>
+      <ErrorPage error={error} />
+    </RootDocument>
+  )
 }
 
 function RootNotFoundComponent() {


### PR DESCRIPTION
## Summary
- Await `requireAuthConfiguration` in the login route `beforeLoad` so the server function runs correctly
- Make the `requireAuthConfiguration` handler async to match other auth guards
- Wrap the root error component in `RootDocument` so error pages render with styles and scripts

## Test plan
- [ ] Visit `/login` with auth secrets configured and confirm the page loads
- [ ] Visit `/login` without `OTP_SECRET` or `SESSION_COOKIE_SECRET` and confirm the configuration error is shown
- [ ] Trigger a root-level error and confirm the error page renders with proper styling

Made with [Cursor](https://cursor.com)