### PR TITLE
feat(core): scaffold prerender and sitemap config in vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,8 @@ import { visualizer } from "rollup-plugin-visualizer"
 import { defineConfig } from "vite"
 import { routes } from "./apps/routes"
 
+// import config from "./packages/config"
+
 const isStorybook = process.argv[1]?.includes("storybook")
 
 export default defineConfig({
@@ -56,6 +58,18 @@ export default defineConfig({
               virtualRouteConfig: routes,
               generatedRouteTree: "routeTree.gen.ts",
             },
+            // Enables prerendering for selected pages and sitemap generation
+            // prerender: {
+            //   enabled: true,
+            //   crawlLinks: true,
+            //   filter: ({ path }) =>
+            //     ["/", "/payments/success"].includes(path) ||
+            //     ["/blog", "/legal"].some((prefix) => path.startsWith(prefix)),
+            // },
+            // sitemap: {
+            //   enabled: true,
+            //   host: config.core.websiteUrl,
+            // },
           }),
           react(),
         ]


### PR DESCRIPTION
## Summary
- Add commented TanStack Start `prerender` config with link crawling and a path filter for `/`, `/blog*`, `/legal*`, and `/payments/success`
- Add commented `sitemap` config wired to `config.core.websiteUrl` for future enablement


Made with [Cursor](https://cursor.com)