### PR TITLE
feat(config): add setup:wrangler script to reset wrangler.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "setup": "bun install && bun run setup:env && playwright install --with-deps chromium && CI=1 bun run db:migrate",
     "setup:env": "cp .init.env .env && cp .init.env.test .env.test",
     "setup:reset": "git clean -fdxq && bun run setup",
+    "setup:wrangler": "bun ./packages/config/scripts/wrangler-reset.ts",
     "storybook": "storybook dev -p 6006 --no-open",
     "test": "bun run db:export && vitest run",
     "test:coverage": "bun run db:export && vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "deploy:production": "CLOUDFLARE_ENV=production bun run build && wrangler deploy",
     "deploy:preview": "CLOUDFLARE_ENV=preview bun run build && wrangler deploy",
     "dev": "NODE_OPTIONS=\"--inspect\" vite dev",
+    "dev:email": "email dev -d ./apps/email/templates -p 3001",
     "doctor": "bun run check && bun run check:types && bun run test",
     "generate": "tsx ./packages/generate/generate.ts",
     "generate:types": "wrangler types",
@@ -42,8 +43,7 @@
     "test:e2e": "playwright test --project=e2e",
     "test:e2e:ui": "playwright test --ui --project=e2e",
     "test:smoke": "playwright test --project=smoke",
-    "test:watch": "bun run db:export && vitest watch",
-    "dev:email": "email dev -d ./apps/email/templates -p 3001"
+    "test:watch": "bun run db:export && vitest watch"
   },
   "dependencies": {
     "@mdx-js/react": "3.1.1",

--- a/packages/config/scripts/wrangler-reset.ts
+++ b/packages/config/scripts/wrangler-reset.ts
@@ -12,8 +12,8 @@ wranglerJson.d1_databases[0].database_name = `${projectName}-development`
 wranglerJson.env.production.d1_databases[0].database_name = `${projectName}-production`
 wranglerJson.env.preview.d1_databases[0].database_name = `${projectName}-preview`
 wranglerJson.env.test.d1_databases[0].database_name = `${projectName}-test`
-wranglerJson.env.production.d1_databases[0].database_id = "<DATABASE_ID>"
-wranglerJson.env.preview.d1_databases[0].database_id = "<DATABASE_ID>"
+delete wranglerJson.env.production.d1_databases[0].database_id
+delete wranglerJson.env.preview.d1_databases[0].database_id
 
 await write("./wrangler.json", JSON.stringify(wranglerJson, null, 2))
 

--- a/packages/config/scripts/wrangler-reset.ts
+++ b/packages/config/scripts/wrangler-reset.ts
@@ -14,6 +14,10 @@ wranglerJson.env.preview.d1_databases[0].database_name = `${projectName}-preview
 wranglerJson.env.test.d1_databases[0].database_name = `${projectName}-test`
 delete wranglerJson.env.production.d1_databases[0].database_id
 delete wranglerJson.env.preview.d1_databases[0].database_id
+wranglerJson.env.production.vars.CLOUDFLARE_TURNSTILE_PUBLIC_KEY = ""
+wranglerJson.env.production.vars.NEWSLETTER_SEGMENT_ID = ""
+wranglerJson.env.preview.vars.CLOUDFLARE_TURNSTILE_PUBLIC_KEY = ""
+wranglerJson.env.preview.vars.NEWSLETTER_SEGMENT_ID = ""
 
 await write("./wrangler.json", JSON.stringify(wranglerJson, null, 2))
 

--- a/packages/config/scripts/wrangler-reset.ts
+++ b/packages/config/scripts/wrangler-reset.ts
@@ -1,0 +1,20 @@
+import { basename } from "node:path"
+import { file, write } from "bun"
+
+const projectName = basename(process.cwd())
+
+console.log(`🔄 Resetting wrangler.json for "${projectName}"...`)
+
+const wranglerJson = await file("./wrangler.json").json()
+
+wranglerJson.name = projectName
+wranglerJson.d1_databases[0].database_name = `${projectName}-development`
+wranglerJson.env.production.d1_databases[0].database_name = `${projectName}-production`
+wranglerJson.env.preview.d1_databases[0].database_name = `${projectName}-preview`
+wranglerJson.env.test.d1_databases[0].database_name = `${projectName}-test`
+wranglerJson.env.production.d1_databases[0].database_id = "<DATABASE_ID>"
+wranglerJson.env.preview.d1_databases[0].database_id = "<DATABASE_ID>"
+
+await write("./wrangler.json", JSON.stringify(wranglerJson, null, 2))
+
+console.log(`✅ Finished resetting wrangler.json for "${projectName}".`)


### PR DESCRIPTION
## Summary
- Add `setup:wrangler` npm script that runs a Bun script to reset `wrangler.json` for a new project
- Derive project name from the root directory name and update D1 database names for all environments
- Remove production/preview `database_id` values and clear production/preview env vars for a clean starter setup

## Test plan
- [ ] Run `bun run setup:wrangler` from a cloned project directory
- [ ] Verify `wrangler.json` name and database names match the directory name
- [ ] Verify production/preview `database_id` fields are removed and vars are empty strings


Made with [Cursor](https://cursor.com)