### PR TITLE
chore: add generate:secret script for random key generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev:email": "email dev -d ./apps/email/templates -p 3001",
     "doctor": "bun run check && bun run check:types && bun run test",
     "generate": "tsx ./packages/generate/generate.ts",
+    "generate:secret": "bun -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
     "generate:types": "wrangler types",
     "git:clean": "git branch -l | grep -v 'main' | xargs git branch -D",
     "git:reset": "rm -rf .git && git init .",


### PR DESCRIPTION
## Summary
- Add `generate:secret` npm script that outputs a 64-character hex string from 32 random bytes
- Useful for generating auth secrets and other cryptographic keys during local setup

## Test plan
- [ ] Run `bun run generate:secret` and verify it prints a 64-character hex string


Made with [Cursor](https://cursor.com)