### PR TITLE
fix(db): validate D1 database ID and format wrangler after reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "setup": "bun install && bun run setup:env && playwright install --with-deps chromium && CI=1 bun run db:migrate",
     "setup:env": "cp .init.env .env && cp .init.env.test .env.test",
     "setup:reset": "git clean -fdxq && bun run setup",
-    "setup:wrangler": "bun ./packages/config/scripts/wrangler-reset.ts",
+    "setup:wrangler": "bun ./packages/config/scripts/wrangler-reset.ts && bun check:fix",
     "storybook": "storybook dev -p 6006 --no-open",
     "test": "bun run db:export && vitest run",
     "test:coverage": "bun run db:export && vitest run --coverage",

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -21,6 +21,10 @@ function getDbId(binding: string, cloudflareEnv?: string) {
     throw new Error(`D1 database binding not found: ${binding}`)
   }
 
+  if (!("database_id" in database)) {
+    throw new Error(`D1 database ID not found: ${binding}`)
+  }
+
   return database.database_id
 }
 


### PR DESCRIPTION
## Summary
- Add explicit validation in `drizzle.config.ts` when a D1 binding exists but `database_id` is missing, producing a clear error instead of failing later
- Run `bun check:fix` after `setup:wrangler` so `wrangler.json` is formatted after the reset script rewrites it

## Test plan
- [ ] Run `bun run setup:wrangler` and confirm `wrangler.json` is formatted
- [ ] Run `bun run db:studio` / `bun run db:migrate` locally and confirm D1 config resolves correctly
- [ ] Verify drizzle config throws a helpful error when `database_id` is absent from a binding


Made with [Cursor](https://cursor.com)