### PR TITLE
fix(newsletter): return not found for invalid confirm params

### DIFF
--- a/apps/newsletter/routes/confirm.tsx
+++ b/apps/newsletter/routes/confirm.tsx
@@ -19,7 +19,7 @@ const confirmSearchSchema = z.object({
 })
 
 export const Route = createFileRoute("/newsletter/confirm")({
-  validateSearch: (search) => confirmSearchSchema.parse(search),
+  validateSearch: confirmSearchSchema,
   loaderDeps: ({ search }) => ({
     email: search.email,
     expiresAt: search.expiresAt,

--- a/apps/newsletter/rpc/confirm.ts
+++ b/apps/newsletter/rpc/confirm.ts
@@ -14,7 +14,13 @@ export const confirmFormSchema = z.object({
 })
 
 export const getConfirmPageData = createServerFn({ method: "GET" })
-  .validator(confirmFormSchema)
+  .validator((data) => {
+    try {
+      return confirmFormSchema.parse(data)
+    } catch {
+      throw notFound()
+    }
+  })
   .handler(async ({ data }) => {
     if (!env.OTP_SECRET) {
       throw new Error("OTP_SECRET is not set")


### PR DESCRIPTION
## Summary
- Pass the Zod search schema directly to `validateSearch` on the newsletter confirm route instead of wrapping it in a manual `.parse()` call
- Catch validation failures in `getConfirmPageData` and throw `notFound()` so malformed or incomplete confirm links return a 404 instead of an unhandled error

## Test plan
- [ ] Open `/newsletter/confirm` with missing or invalid query params and verify a 404 is shown
- [ ] Open a valid signed confirm link and verify the confirmation page loads and submission still works


Made with [Cursor](https://cursor.com)