### PR TITLE
fix(wrangler): drop trailing slash in static asset HTML handling

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -5,7 +5,8 @@
   "main": "@tanstack/react-start/server-entry",
   "assets": {
     "directory": "./dist/client",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "html_handling": "drop-trailing-slash"
   },
   "preview_urls": true,
   "observability": {


### PR DESCRIPTION
## Summary
- Configure Cloudflare Workers assets `html_handling` to `drop-trailing-slash` in `wrangler.json`
- Ensures consistent URL behavior for static HTML assets served via the ASSETS binding

## Test plan
- [ ] Deploy to preview environment and verify routes with trailing slashes redirect or resolve correctly
- [ ] Confirm static HTML pages load without duplicate content at `/path` vs `/path/`


Made with [Cursor](https://cursor.com)