### PR TITLE
chore(deps): upgrade @polar-sh/sdk to 0.49.0

### DIFF
--- a/apps/payments/handlers.server.ts
+++ b/apps/payments/handlers.server.ts
@@ -16,6 +16,11 @@ import type {
 export async function onPaymentSuccess(
   event: WebhookOrderPaidPayload | WebhookSubscriptionActivePayload,
 ) {
+  const email = event.data.customer.email
+  if (!email) {
+    throw new Error("Customer email not found")
+  }
+
   try {
     const productId = event.data.productId
     const productConfig = Object.values(config.payments.products).find(
@@ -27,7 +32,7 @@ export async function onPaymentSuccess(
     if (!productConfig) {
       throw new Error("Product not found")
     }
-    const user = await getOrCreateUserByEmail(event.data.customer.email)
+    const user = await getOrCreateUserByEmail(email)
     const userRoleToGrant = productConfig.userRoleToGrant
     if (await hasUserRole(user.id, userRoleToGrant)) {
       throw new Error("User already has access")
@@ -44,9 +49,7 @@ export async function onPaymentSuccess(
         return new Response(error.message, { status: 200 })
       }
       if (error.message === "Product not found") {
-        await sendAccessFailureEmail({
-          to: event.data.customer.email,
-        })
+        await sendAccessFailureEmail({ to: email })
         return new Response(error.message, { status: 200 })
       }
     }
@@ -57,6 +60,11 @@ export async function onPaymentSuccess(
 export async function onPaymentRevoked(
   event: WebhookOrderRefundedPayload | WebhookSubscriptionRevokedPayload,
 ) {
+  const email = event.data.customer.email
+  if (!email) {
+    throw new Error("Customer email not found")
+  }
+
   try {
     const productId = event.data.productId
     const productConfig = Object.values(config.payments.products).find(
@@ -68,7 +76,7 @@ export async function onPaymentRevoked(
     if (!productConfig) {
       throw new Error("Product not found")
     }
-    const user = await getUserByEmail(event.data.customer.email)
+    const user = await getUserByEmail(email)
     if (!user) {
       throw new Error("User not found")
     }

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "pagezero",
       "dependencies": {
         "@mdx-js/react": "3.1.1",
-        "@polar-sh/sdk": "0.41.1",
+        "@polar-sh/sdk": "0.49.0",
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-router": "1.170.15",
         "@tanstack/react-start": "1.168.25",
@@ -396,7 +396,7 @@
 
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
-    "@polar-sh/sdk": ["@polar-sh/sdk@0.41.1", "", { "dependencies": { "standardwebhooks": "^1.0.0", "zod": "^3.25.76" } }, "sha512-yMG9HJvdHdqw6Q1JrisqIyTrX47gF4Q1rYaJGyJDuel0EPeZ1P2robrERzg86EM2NIXWy+0vR36nNSw5gRBdPQ=="],
+    "@polar-sh/sdk": ["@polar-sh/sdk@0.49.0", "", { "dependencies": { "standardwebhooks": "^1.0.0", "zod": "^3.25.65 || ^4.0.0" } }, "sha512-9UYb70iKjJCtWYlu0OF5HLYBLmkxHwqr2RlXwuxXQgRGqq56IQWlVG+NO7e1YJ7I5GW0CBHhGIjRbQ9hYM6ycQ=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -1768,7 +1768,7 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
-    "@polar-sh/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "@polar-sh/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@poppinss/colors/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "3.1.1",
-    "@polar-sh/sdk": "0.41.1",
+    "@polar-sh/sdk": "0.49.0",
     "@tanstack/react-query": "5.101.0",
     "@tanstack/react-router": "1.170.15",
     "@tanstack/react-start": "1.168.25",


### PR DESCRIPTION
## Summary
- Upgrade `@polar-sh/sdk` from 0.41.1 to 0.49.0
- Validate customer email in payment webhook handlers, since the SDK now types it as nullable

## Test plan
- [ ] `bun run check:types`
- [ ] `bun run test` (payments webhook coverage)

Made with [Cursor](https://cursor.com)