### PR TITLE
chore: re-enable oxlint rules and fix violations

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,10 +10,7 @@
     }
   },
   "rules": {
-    "react/react-in-jsx-scope": "off",
-    "unicorn/consistent-function-scoping": "off",
-    "unicorn/no-array-sort": "off",
-    "no-shadow": "off"
+    "react/react-in-jsx-scope": "off"
   },
   "ignorePatterns": [
     "packages/db/*/migrations/meta/*",

--- a/apps/blog/routes/index.tsx
+++ b/apps/blog/routes/index.tsx
@@ -7,7 +7,7 @@ import { getMdxFrontmatters } from "@/mdx"
 
 export const Route = createFileRoute("/_brand-layout/blog")({
   loader: () => ({
-    posts: getMdxFrontmatters(postModules, blogPostFrontmatterSchema).sort(
+    posts: getMdxFrontmatters(postModules, blogPostFrontmatterSchema).toSorted(
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
     ),
   }),

--- a/packages/form/use-form-action.ts
+++ b/packages/form/use-form-action.ts
@@ -79,10 +79,10 @@ export function useFormAction<
   const mutation = useMutation({
     ...options,
     mutationFn: (formData: FormData) => runServerFn({ data: formData }),
-    onSettled: (data, error, ...rest) => {
-      setData(data)
-      setError(error)
-      options?.onSettled?.(data, error, ...rest)
+    onSettled: (settledData, settledError, ...rest) => {
+      setData(settledData)
+      setError(settledError)
+      options?.onSettled?.(settledData, settledError, ...rest)
     },
   })
 

--- a/packages/test/mock-server-fn.ts
+++ b/packages/test/mock-server-fn.ts
@@ -11,17 +11,17 @@
  * }))
  * ```
  */
-export function mockServerFn() {
-  const createServerFn = () => {
-    const builder = {
-      validator: () => builder,
-      handler:
-        <TData, TResult>(handler: (ctx: { data: TData }) => TResult) =>
-        (opts?: { data: TData }) =>
-          handler({ data: opts?.data as TData }),
-    }
-    return builder
+function createServerFn() {
+  const builder = {
+    validator: () => builder,
+    handler:
+      <TData, TResult>(handler: (ctx: { data: TData }) => TResult) =>
+      (opts?: { data: TData }) =>
+        handler({ data: opts?.data as TData }),
   }
+  return builder
+}
 
+export function mockServerFn() {
   return { createServerFn }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts", "**/*.tsx", "apps/routeTree.gen.ts"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "types": ["node", "./worker-configuration.d.ts", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Re-enable `no-shadow`, `unicorn/no-array-sort`, and `unicorn/consistent-function-scoping` in oxlint
- Fix shadowed mutation callbacks, prefer `toSorted`, and hoist `createServerFn` in the test mock
- Bump TypeScript `lib` to ES2023 so `toSorted` type-checks


Made with [Cursor](https://cursor.com)