### PR TITLE
style(mdx): highlight fenced code with the highlight.js theme

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "drizzle-orm": "0.45.2",
+        "highlight.js": "11.11.1",
         "lucide-react": "1.26.0",
         "motion": "12.42.2",
         "radix-ui": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "drizzle-orm": "0.45.2",
+    "highlight.js": "11.11.1",
     "lucide-react": "1.26.0",
     "motion": "12.42.2",
     "radix-ui": "1.6.5",

--- a/packages/mdx/code-highlight.css
+++ b/packages/mdx/code-highlight.css
@@ -1,38 +1,8 @@
-/* Minimal syntax highlighting for MDX fenced code blocks */
+@import "highlight.js/styles/stackoverflow-dark.css";
 
+/* Let the MDX pre wrapper own background, padding, and base text color */
 pre code.hljs {
-  color: inherit;
   background: transparent;
-}
-
-.hljs-keyword,
-.hljs-built_in {
-  color: var(--chart-3);
-}
-
-.hljs-type {
-  color: var(--chart-1);
-}
-
-.hljs-string,
-.hljs-template-variable {
-  color: var(--chart-2);
-}
-
-.hljs-title.function_,
-.hljs-variable.language_ {
-  color: var(--foreground);
-}
-
-.hljs-subst {
-  color: var(--chart-5);
-}
-
-.hljs-comment {
-  color: var(--muted-foreground);
-}
-
-.hljs-number,
-.hljs-literal {
-  color: var(--chart-4);
+  color: inherit;
+  padding: 0;
 }


### PR DESCRIPTION
## Summary
- Add `highlight.js` and import the Stack Overflow dark stylesheet for MDX fenced code blocks.
- Drop the chart-token color rules so highlighting matches the website approach. The existing `pre` wrapper still owns background and padding.

## Test plan
- [ ] Open a blog post with a fenced code block and confirm syntax colors come from the highlight.js theme
- [ ] Confirm inline `code` is unchanged


Made with [Cursor](https://cursor.com)