### PR TITLE
docs: rewrite AGENTS.md as accurate agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,115 +1,98 @@
 # AGENTS.md
 
-> Guidelines for AI coding agents working in the PageZERO codebase.
+Guidelines for AI coding agents working in the PageZERO codebase.
 
-## Project Overview
+PageZERO is a full-stack TypeScript starter for Cloudflare: TanStack Start, Workers, and D1.
 
-PageZERO is a full-stack TypeScript web application starter built for Cloudflare. It uses TanStack Start, Cloudflare Workers (hosting), and Cloudflare D1 (database).
+**Frontend**: React 19, TanStack Router / Start / Query, Tailwind CSS 4, Radix UI
+**Backend**: Cloudflare Workers, Drizzle ORM, D1, Better Auth (email OTP, Polar.sh)
+**Tooling**: Bun, Oxlint, Oxfmt, Vitest, Playwright, Storybook
+**Email / payments**: React Email + Resend; Polar.sh via Better Auth
 
-### Tech Stack
-
-- **Frontend**: React 19, TanStack Router, TanStack Start, TanStack Query, TailwindCSS 4, Radix UI
-- **Backend**: Cloudflare Workers, Drizzle ORM, D1 SQLite, Better Auth
-- **Tooling**: Bun (package manager), Oxlint (linting), Oxfmt (formatting), Vitest (unit tests), Playwright (e2e tests), Storybook (UI development)
-- **Email**: React Email, Resend
-- **Payments**: Polar.sh integration (via Better Auth Polar plugin)
-
-## Project Structure
+## Layout
 
 ```
-├── apps/                    # Feature modules (domain-specific code)
-│   ├── auth/               # Authentication (Better Auth: email OTP, sessions, access control)
-│   ├── brand/              # Marketing pages and brand components
-│   ├── core/               # App shell (root, routes, styles)
-│   ├── email/              # Email templates and sending logic
-│   ├── payments/           # Payment integration (Polar.sh via Better Auth)
-│   ├── root.tsx            # App root route (createRootRoute)
-│   ├── router.tsx          # Router factory (createRouter + QueryClient)
-│   ├── routes.ts           # Virtual route config (rootRoute, layout, route)
-│   └── routeTree.gen.ts    # Auto-generated route tree (do not edit manually)
+├── apps/                      # Feature modules
+│   ├── auth/                  # Better Auth: OTP, sessions, access control
+│   ├── blog/                  # MDX posts and blog routes
+│   ├── brand/                 # Marketing pages, legal MDX, brand UI
+│   ├── core/                  # App shell, styles, mode
+│   ├── email/                 # Templates and sending
+│   ├── newsletter/            # Signup and confirm flow
+│   ├── payments/              # Polar.sh via Better Auth
+│   ├── root.tsx               # Root route (createRootRoute)
+│   ├── router.tsx             # Router factory + QueryClient
+│   ├── routes.ts              # Virtual route config — add routes here
+│   └── routeTree.gen.ts       # Generated — never edit
 │
-├── packages/               # Shared, reusable code
-│   ├── config/            # Application configuration
-│   ├── crypto/            # Cryptographic utilities
-│   ├── db/                # Database schema, migrations, scripts
-│   ├── types/             # Shared TypeScript types
-│   ├── ui/                # UI component library (shadcn-style)
-│   └── ui-lite/           # Lightweight UI components (no external deps)
+├── packages/                  # Shared code (`@/` maps here first)
+│   ├── cloudflare/            # Turnstile, Workers test stub
+│   ├── config/                # App configuration
+│   ├── crypto/                # Server-side crypto
+│   ├── date/                  # Date helpers
+│   ├── db/                    # D1 access, generated schema barrel, migrations
+│   ├── form/                  # parseFormData, useFormAction
+│   ├── mdx/                   # MDX helpers and provider
+│   ├── test/                  # mockServerFn for RPC unit tests
+│   ├── types/                 # Shared TypeScript utilities
+│   ├── ui/                    # shadcn-style components
+│   └── ui-lite/               # Lightweight UI (no external deps)
 │
-├── e2e/                    # Playwright end-to-end tests
-└── public/                 # Static assets
+├── e2e/                       # Playwright (local `*.spec.ts`, deployed `smoke.spec.ts`)
+├── public/                    # Static assets
+└── .agents/skills/            # Agent skills — use these instead of hand-rolling
 ```
 
-## Path Aliases
-
-Use `@/` prefix for imports which maps to both `./packages/*` and `./apps/*`:
+`@/` maps to `./packages/*` then `./apps/*`:
 
 ```typescript
 import { Button } from "@/ui/button"
-import { getUserId } from "@/user"
+import { getUser } from "@/auth/rpc"
 ```
 
-## Coding Conventions
+## Hard rules
 
-### TypeScript
+- `import type` is required (`verbatimModuleSyntax`). Prefer `interface` for object shapes; export types next to implementations.
+- Never import `*.server.ts` from client components, hooks, or route `component` functions. Call `createServerFn` exports from `rpc/` instead.
+- Never put `createServerFn` in a route file. It lives in the feature's `rpc/` directory.
+- Never edit `apps/routeTree.gen.ts` or `worker-configuration.d.ts` (`bun run generate:types`).
+- Register every route in `apps/routes.ts`. After schema changes run `bun run db:generate`.
+- Reuse existing auth guards from `@/auth/rpc` (`requireUserId`, `requireGuestUser`, `requireUserPermissions`, `requireUserRole`). Do not invent new redirects.
+- Mutations use `@/form` (`parseFormData` in the RPC validator, `useFormAction` on the client). Do not ad-hoc `fetch`.
+- Prefer `packages/ui` before adding a new primitive. `env` from `cloudflare:workers` only inside server functions / `*.server.ts`.
+- Do not commit `.env` or `.env.test`. Copy from `.init.env` / `.init.env.test`.
 
-- Strict mode enabled
-- Use `type` keyword for type imports when possible
-- Prefer interfaces for object shapes, types for unions/intersections
-- Export types alongside implementations
+## How we do work
 
-### File Naming
+### File naming
 
-- Components: `kebab-case.tsx` (e.g., `checkout-button.tsx`)
-- Tests: `*.test.ts` for node tests, `*.test.tsx` for DOM tests
-- Stories: `*.stories.tsx`
-- Server-only code: `*.server.ts` (e.g., `auth.server.ts`) — internal helpers, not callable from the client
-- Client-only code: `*.client.ts` — browser-only modules, not importable from the server
-- RPC endpoints: `rpc/` directory (e.g., `auth/rpc/get-user.ts`) — `createServerFn` exports
-- Index files: `index.ts` for public exports
+- Components: `kebab-case.tsx`. Tests: `*.test.ts` (Node) / `*.test.tsx` (happy-dom). Stories: `*.stories.tsx`.
+- Server-only: `*.server.ts`. Client-only: `*.client.ts`. Public API: `index.ts`.
 
-### Component Structure
+### Components
 
-Each UI component follows this pattern:
+Use the `create-component` skill. Folder shape:
 
 ```
 component-name/
-├── index.ts              # Re-exports public API
-├── component-name.tsx    # Component implementation
+├── index.ts
+├── component-name.tsx
 ├── component-name.test.tsx
 └── component-name.stories.tsx
 ```
 
-### React Components
+Function components, `ComponentNameProps`, `cn()` from `@/ui/utils`, `cva` for variants. Story titles: `"Apps/ModuleName/ComponentName"` or `"Packages/UI/ComponentName"`. Theme tokens live in `apps/core/styles/tailwind.css` (`change-theme` skill).
 
-- Use function components with explicit props types
-- Props type naming: `ComponentNameProps`
-- Use `cn()` utility for className merging (from `@/ui/utils`)
-- Use `cva` (class-variance-authority) for component variants
+### Routes and RPC
 
-```typescript
-interface ButtonProps {
-  variant?: "default" | "outline"
-  size?: "sm" | "lg"
-}
-
-function Button({ variant, size, className, ...props }: ButtonProps) {
-  return <button className={cn(buttonVariants({ variant, size }), className)} {...props} />
-}
-
-export { Button, type ButtonProps }
-```
-
-### Route Files
-
-Routes use TanStack Router conventions with `createFileRoute`. Callable server logic lives in the feature module's `rpc/` directory as `createServerFn` exports:
+TanStack Router `createFileRoute`. Loaders and actions call `rpc/` server functions. `beforeLoad` for guards. `validateSearch` (Zod) for search params.
 
 ```typescript
 // apps/auth/rpc/get-user.ts
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 
-import { auth } from "@/auth/auth.server"
+import { auth } from "../auth.server"
 
 export const getUser = createServerFn({ method: "GET" }).handler(async () => {
   const session = await auth.api.getSession({ headers: getRequestHeaders() })
@@ -118,216 +101,91 @@ export const getUser = createServerFn({ method: "GET" }).handler(async () => {
 ```
 
 ```typescript
-// apps/auth/routes/profile.tsx
-import { createFileRoute } from "@tanstack/react-router"
-import { getUser } from "@/auth/rpc"
-
-export const Route = createFileRoute("/profile")({
-  loader: () => getUser(),
-  component: PageComponent,
+// apps/auth/routes/login.tsx — guards already exist
+export const Route = createFileRoute("/login")({
+  validateSearch: (search) => loginSearchSchema.parse(search),
+  beforeLoad: async () => {
+    await requireAuthConfiguration()
+    await requireGuestUser()
+  },
+  loader: async ({ deps }) => getLoginPageData({ data: { redirectTo: deps.redirectTo } }),
+  component: Login,
 })
-
-function PageComponent() {
-  const { user } = Route.useLoaderData()
-  // render...
-}
 ```
 
-- Use `beforeLoad` for auth guards (call a `createServerFn` that throws `redirect` if not authenticated)
-- Use `validateSearch` for typed search params
-- Access environment variables via `import { env } from "cloudflare:workers"` inside server functions
+Add or remove paths only in `apps/routes.ts` (see that file for the live tree: `/`, `/legal/$slug`, `/blog`, `/login`, `/newsletter/confirm`, `/payments/success`, …).
 
-### Route Registration
-
-Routes are declared in `apps/routes.ts` using `@tanstack/virtual-file-routes` and referenced in `vite.config.ts`. After adding or removing routes, TanStack Router auto-regenerates `apps/routeTree.gen.ts` — do **not** edit that file manually.
+### Forms
 
 ```typescript
-// apps/routes.ts
-import { index, layout, rootRoute, route } from "@tanstack/virtual-file-routes"
+// RPC
+.validator((data: FormData) => parseFormData(loginFormSchema, data))
 
-export const routes = rootRoute("root.tsx", [
-  layout("brand-layout", "brand/routes/layout.tsx", [
-    index("brand/routes/home.tsx"),
-    route("/privacy", "brand/routes/privacy.tsx"),
-  ]),
-  route("/login", "auth/routes/login.tsx"),
-])
+// Client
+const { data, error, isPending, onSubmit } = useFormAction(loginFormSchema, loginFormAction)
 ```
+
+Turnstile: `@/cloudflare/turnstile`.
 
 ### Database
 
-- Schema defined in `packages/db/schema.ts` (auto-generated imports)
-- Feature schemas in `apps/*/db/schema.ts`
-- Access the database via `getMainDb()` from `@/db/main` inside server functions:
+Feature tables in `apps/*/db/schema.ts`. `packages/db/main/schema.ts` is the generated barrel (do not hand-edit exports). Access via `getMainDb()` from `@/db/main` inside server code. Drizzle Kit config: `packages/db/drizzle.config.ts` (root `drizzle.config.ts` re-exports it).
 
 ```typescript
 import { getMainDb } from "@/db/main"
 
-const getData = createServerFn({ method: "GET" }).handler(async () => {
-  const db = getMainDb()
-  // use Drizzle ORM...
-})
+const db = getMainDb()
 ```
 
-- Run `bun run db:generate` after schema changes
+Then `bun run db:generate` and `bun run db:migrate`.
 
-### Data Fetching (Client)
+### Content (MDX)
 
-Use TanStack Query for client-side data fetching. Server functions (`createServerFn`) are used as query functions:
+Blog posts: `apps/blog/content/*.mdx`. Legal: `apps/brand/content/legal/*.mdx`. Load with `import.meta.glob` plus `@/mdx` (`getMdxFrontmatters`, `getMdxModuleBySlug`). Do not turn articles into React page components.
+
+### Client data
+
+TanStack Query with server functions as `queryFn`. Reuse `useUser` from `@/auth/hooks` for the session.
 
 ```typescript
-import { useQuery } from "@tanstack/react-query"
-import { getUser } from "@/auth/rpc"
-
-function MyComponent() {
-  const { data } = useQuery({
-    queryKey: ["user"],
-    queryFn: () => getUser(),
-  })
-}
+useQuery({ queryKey: ["user"], queryFn: () => getUser() })
 ```
 
 ### Tests
 
-**Unit Tests (Vitest)**:
+- Vitest: `describe` / `it` / `expect`; Testing Library for DOM. RPC unit tests mock `createServerFn` with `@/test/mock-server-fn`.
+- Playwright: `e2e/*.spec.ts` against local; `e2e/smoke.spec.ts` against the deployed URL (`bun run test:smoke`).
 
-- Node tests: `*.test.ts` - run in Node environment
-- DOM tests: `*.test.tsx` - run in happy-dom environment
-- Use `describe`, `it`, `expect` from vitest
-- Use `@testing-library/react` for component tests
+### New feature module
 
-```typescript
-import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+1. `apps/feature-name/` with `index.ts`, `routes/`, `components/`, and `db/schema.ts` if needed.
+2. Register routes in `apps/routes.ts`.
+3. Generate DB migrations if the schema changed.
 
-describe("<Component />", () => {
-  it("renders", () => {
-    render(<Component />)
-    expect(screen.getByText("text")).toBeInTheDocument()
-  })
-})
-```
+## Skills
 
-**E2E Tests (Playwright)**:
+| Skill | When |
+| ----- | ---- |
+| `.agents/skills/create-component/SKILL.md` | New UI component in `packages/ui` or `apps/*/components` |
+| `.agents/skills/change-theme/SKILL.md` | Colors / theme in `apps/core/styles/tailwind.css` |
+| `.agents/skills/create-pr/SKILL.md` | Open or push a pull request |
+| `.agents/skills/merge-pr/SKILL.md` | Squash-merge the PR for the current branch |
 
-- Located in `e2e/` directory
-- Smoke tests: `*.smoke.spec.ts` - run against deployed environments
-- Regular e2e: `*.spec.ts` - run against local dev server
-
-### Storybook
-
-- Stories go alongside components
-- Use `Meta` and `StoryObj` types from `@storybook/tanstack-react`
-- Title format: `"Apps/ModuleName/ComponentName"` or `"Packages/UI/ComponentName"`
-
-```typescript
-import type { Meta, StoryObj } from "@storybook/tanstack-react"
-
-const meta = {
-  title: "Packages/UI/Button",
-  component: Button,
-  parameters: { layout: "centered" },
-  tags: ["autodocs"],
-} satisfies Meta<typeof Button>
-
-export default meta
-type Story = StoryObj<typeof meta>
-
-export const Primary: Story = {
-  args: { children: "Button" },
-}
-```
-
-## Code Quality
-
-### Formatting & Linting
-
-- **Oxlint** handles linting; **Oxfmt** handles formatting
-- Indentation: 2 spaces
-- Quotes: double quotes
-- Semicolons: as needed (ASI)
-- Config: `.oxlintrc.json` (lint), `.oxfmtrc.json` (format)
-
-Run checks:
+## Scripts
 
 ```bash
-bun run check        # Format check, lint, and type check
-bun run check:fix    # Auto-fix format/lint, then type check
+bun run check        # oxfmt --check, oxlint, tsc
+bun run check:fix    # oxfmt + oxlint --fix (does not run tsc)
+bun run test         # unit tests
+bun run test:e2e     # local Playwright
+bun run test:smoke   # deployed Playwright
+bun run db:generate  # after schema changes
+bun run db:migrate   # apply D1 migrations locally
+bun run generate:types  # wrangler types → worker-configuration.d.ts
 ```
 
-## Common Scripts
-
-```bash
-bun run dev          # Start development server (localhost:3000)
-bun run build        # Production build
-bun run preview      # Preview production build locally
-bun run test         # Run unit tests
-bun run test:watch   # Run tests in watch mode
-bun run test:e2e:ui  # Run e2e tests with UI
-bun run storybook    # Start Storybook (localhost:6006)
-bun run db:studio    # Open Drizzle Studio
-bun run db:migrate   # Run database migrations
-```
-
-## Adding New Features
-
-### New UI Component
-
-1. Use the `create-component` skill (`.agents/skills/create-component/SKILL.md`) to scaffold
-2. Or manually: create folder in `packages/ui/component-name/` and add `component-name.tsx`, `index.ts`, `component-name.test.tsx`, `component-name.stories.tsx`
-
-### New Feature Module
-
-1. Create folder in `apps/feature-name/`
-2. Add `index.ts` for public exports
-3. Add routes in `routes/` subfolder using `createFileRoute`
-4. Add components in `components/` subfolder
-5. If database tables needed, add `db/schema.ts`
-6. Register routes in `apps/routes.ts`
-
-### New Database Table
-
-1. Add schema in appropriate `apps/*/db/schema.ts`
-2. Run `bun run db:generate` to create migration
-3. Run `bun run db:migrate` to apply locally
+CI is `.github/workflows/deploy.yml` (check → unit → e2e → migrate → deploy → smoke). `main` is production; PRs are preview.
 
 ## Environment
 
-- Node.js >= 24
-- Bun >= 1.3
-- Environment files: `.env` (local), `.env.test` (tests)
-- Copy from `.init.env` and `.init.env.test` for initial setup
-
-## CI/CD Pipeline
-
-GitHub Actions workflow (`.github/workflows/deploy.yml`):
-
-1. Quality check (format, lint, types)
-2. Unit tests (Vitest)
-3. E2E tests (Playwright)
-4. Database migration
-5. Deploy to Cloudflare Workers
-6. Smoke tests against deployed URL
-
-- **main branch**: deploys to production
-- **PRs**: deploy to preview environment
-
-## Key Files Reference
-
-| File                        | Purpose                                                    |
-| --------------------------- | ---------------------------------------------------------- |
-| `apps/routes.ts`            | Virtual route config (add new routes here)                 |
-| `apps/routeTree.gen.ts`     | Auto-generated route tree (do not edit)                    |
-| `apps/root.tsx`             | App root route and document shell                          |
-| `apps/router.tsx`           | Router factory with QueryClient setup                      |
-| `packages/db/schema.ts`     | Database schema exports                                    |
-| `packages/db/main/index.ts` | `getMainDb()` helper for database access                   |
-| `packages/config/index.ts`  | App configuration                                          |
-| `apps/auth/auth.server.ts`  | Better Auth instance (email OTP, captcha, admin AC, Polar) |
-| `apps/auth/auth.ts`         | Better Auth client                                         |
-| `apps/auth/access.ts`       | Access-control roles (`user`, `admin`, `premium`, `elite`) |
-| `vite.config.ts`            | Vite + TanStack Start + Vitest configuration               |
-| `.oxlintrc.json`            | Oxlint rules                                               |
-| `.oxfmtrc.json`             | Oxfmt formatting options                                   |
-| `drizzle.config.ts`         | Database configuration                                     |
-| `wrangler.json`             | Cloudflare Workers config                                  |
+Node.js >= 24, Bun >= 1.3. Local env: `.env` / `.env.test` from `.init.env` / `.init.env.test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,12 +164,12 @@ useQuery({ queryKey: ["user"], queryFn: () => getUser() })
 
 ## Skills
 
-| Skill | When |
-| ----- | ---- |
+| Skill                                      | When                                                     |
+| ------------------------------------------ | -------------------------------------------------------- |
 | `.agents/skills/create-component/SKILL.md` | New UI component in `packages/ui` or `apps/*/components` |
-| `.agents/skills/change-theme/SKILL.md` | Colors / theme in `apps/core/styles/tailwind.css` |
-| `.agents/skills/create-pr/SKILL.md` | Open or push a pull request |
-| `.agents/skills/merge-pr/SKILL.md` | Squash-merge the PR for the current branch |
+| `.agents/skills/change-theme/SKILL.md`     | Colors / theme in `apps/core/styles/tailwind.css`        |
+| `.agents/skills/create-pr/SKILL.md`        | Open or push a pull request                              |
+| `.agents/skills/merge-pr/SKILL.md`         | Squash-merge the PR for the current branch               |
 
 ## Scripts
 


### PR DESCRIPTION
## Summary
- Rewrite `AGENTS.md` around current layout (blog, newsletter, form, mdx, cloudflare) and real scripts/paths
- Replace tutorial copy-paste with hard rules: `import type`, `rpc/` vs `*.server.ts`, existing auth guards, `@/form`, MDX content
- Point agents at skills (`create-component`, `change-theme`, `create-pr`, `merge-pr`) instead of duplicating them

## Test plan
- [ ] Skim `AGENTS.md` against `apps/routes.ts`, `package.json` scripts, and `.agents/skills/`
- [ ] Confirm no leftover stale paths (`@/user`, `packages/db/schema.ts`, `/privacy`, `*.smoke.spec.ts`)


Made with [Cursor](https://cursor.com)